### PR TITLE
[Feat] 랜딩페이지 / 인기강의 및 CTA 섹션 UI 구현

### DIFF
--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router'
 import Button from '../components/common/Button'
+import ImageCards from '../components/common/ImageCards'
 
 function MainPage() {
   const navigate = useNavigate()
@@ -32,7 +33,7 @@ function MainPage() {
             </Button>
 
             <Button
-              onClick={() => navigate('/studygroups')} //임시경로작성
+              onClick={() => navigate('/studygroups')} // 임시경로작성
               className="!border-primary-500 !text-primary-600 hover:!bg-primary-100 !h-[48px] !w-full max-w-[300px] !rounded-[8px] !border sm:!h-[50px] sm:!w-[177px]"
             >
               스터디 그룹 참여
@@ -53,7 +54,6 @@ function MainPage() {
       {/* Feature Section */}
       <section className="flex w-full flex-col items-center justify-center bg-white px-6 py-12 sm:px-8 sm:py-16">
         <div className="w-full max-w-[1280px] text-center">
-          {/* 제목 */}
           <div className="mx-auto mb-10 w-full max-w-[1216px]">
             <h2 className="mb-3 text-[20px] font-extrabold text-gray-900 sm:mb-4 sm:text-[24px]">
               왜 StudyHub를 선택해야할까요?
@@ -64,9 +64,7 @@ function MainPage() {
             </p>
           </div>
 
-          {/* Feature 아이템 3개 */}
           <div className="flex flex-col items-center gap-10 sm:flex-row sm:justify-center sm:gap-16">
-            {/* 1. 다양한 IT 강의 */}
             <div className="flex w-full max-w-[360px] flex-col items-center text-center sm:max-w-[384px]">
               <div className="mb-4 flex h-[64px] w-[64px] items-center justify-center rounded-full bg-yellow-100 text-2xl text-yellow-500 sm:h-[80px] sm:w-[80px] sm:text-3xl">
                 💻
@@ -81,7 +79,6 @@ function MainPage() {
               </p>
             </div>
 
-            {/* 2. 스터디 그룹 */}
             <div className="flex w-full max-w-[360px] flex-col items-center text-center sm:max-w-[384px]">
               <div className="mb-4 flex h-[64px] w-[64px] items-center justify-center rounded-full bg-green-100 text-2xl text-green-500 sm:h-[80px] sm:w-[80px] sm:text-3xl">
                 👥
@@ -96,7 +93,6 @@ function MainPage() {
               </p>
             </div>
 
-            {/* 3️. 전문 강사진 */}
             <div className="flex w-full max-w-[360px] flex-col items-center text-center sm:max-w-[384px]">
               <div className="mb-4 flex h-[64px] w-[64px] items-center justify-center rounded-full bg-purple-100 text-2xl text-purple-500 sm:h-[80px] sm:w-[80px] sm:text-3xl">
                 🎓
@@ -110,6 +106,61 @@ function MainPage() {
                 고품질의 강의 콘텐츠를 만나보세요.
               </p>
             </div>
+          </div>
+        </div>
+      </section>
+
+      {/* 인기 강의 섹션 */}
+      <section className="flex w-full flex-col items-center justify-center bg-white px-6 py-16 sm:px-8">
+        <div className="w-full max-w-[1280px]">
+          <div className="mb-10 flex items-end justify-between">
+            <div>
+              <h2 className="text-[20px] font-extrabold text-gray-900 sm:text-[24px]">
+                인기 강의
+              </h2>
+              <p className="text-[14px] text-gray-600 sm:text-[16px]">
+                지금 가장 많은 사람들이 수강하는 강의들
+              </p>
+            </div>
+            <button className="text-primary-600 text-[14px] font-medium">
+              모든 강의 보기 →
+            </button>
+          </div>
+
+          <div className="flex flex-col items-center gap-8 sm:flex-row sm:justify-between">
+            {[
+              {
+                title: 'React 완전 마스터 강의',
+                description: '김개발',
+                date: '₩59,000원',
+                imageUrl:
+                  'https://images.unsplash.com/photo-1633356122544-f134324a6cee?q=80&w=1200&auto=format&fit=crop',
+              },
+              {
+                title: 'Python 데이터 사이언스',
+                description: '이분석',
+                date: '₩99,000원',
+                imageUrl:
+                  'https://images.unsplash.com/photo-1551434678-e076c223a692?q=80&w=1200&auto=format&fit=crop',
+              },
+              {
+                title: 'AWS 클라우드 아키텍처',
+                description: '한클라우드',
+                date: '₩129,000원',
+                imageUrl:
+                  'https://images.unsplash.com/photo-1504384308090-c894fdcc538d?q=80&w=1200&auto=format&fit=crop',
+              },
+            ].map((course, index) => (
+              <ImageCards
+                key={index}
+                title={course.title}
+                description={course.description}
+                date={course.date}
+                imageUrl={course.imageUrl}
+                size="w-full sm:w-[384px] h-[17.375rem]"
+                onClick={() => navigate('/popularcourses')} // 임시경로작성
+              />
+            ))}
           </div>
         </div>
       </section>

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -128,7 +128,7 @@ function MainPage() {
             </button>
           </div>
 
-          <div className="flex flex-col items-center gap-8 sm:flex-row sm:justify-between">
+          <div className="grid grid-cols-1 gap-8 sm:grid-cols-3 sm:gap-10">
             {[
               {
                 title: 'React 완전 마스터 강의',
@@ -159,7 +159,7 @@ function MainPage() {
                 date={course.date}
                 imageUrl={course.imageUrl}
                 size="w-full sm:w-[384px] h-[17.375rem]"
-                onClick={() => navigate('/popularcourses')} //임시경로작성
+                onClick={() => navigate('/popularcourses')} // 임시 경로
               />
             ))}
           </div>

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -127,8 +127,7 @@ function MainPage() {
               모든 강의 보기 →
             </button>
           </div>
-
-          <div className="grid grid-cols-1 gap-8 sm:grid-cols-3 sm:gap-10">
+          <div className="flex flex-wrap justify-center gap-8 sm:gap-10">
             {[
               {
                 title: 'React 완전 마스터 강의',

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -110,7 +110,7 @@ function MainPage() {
         </div>
       </section>
 
-      {/* 인기 강의 섹션 */}
+      {/* 인기 강의 Section  */}
       <section className="flex w-full flex-col items-center justify-center bg-white px-6 py-16 sm:px-8">
         <div className="w-full max-w-[1280px]">
           <div className="mb-10 flex items-end justify-between">
@@ -161,6 +161,35 @@ function MainPage() {
                 onClick={() => navigate('/popularcourses')} // 임시경로작성
               />
             ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA Section */}
+      <section className="flex w-full justify-center bg-[#E0B43A] px-6 py-20">
+        <div className="flex w-full max-w-[1280px] flex-col items-center text-center text-white">
+          <h2 className="mb-4 text-[24px] leading-[32px] font-extrabold sm:text-[28px] sm:leading-[38px]">
+            지금 시작하여 IT 전문가가 되어보세요!
+          </h2>
+          <p className="mb-10 text-[16px] leading-[26px] sm:text-[18px] sm:leading-[28px]">
+            수백 개의 강의와 활발한 스터디 그룹이 여러분을 기다리고 있습니다.
+          </p>
+
+          <div className="flex flex-col items-center gap-4 sm:flex-row sm:gap-6">
+            <Button
+              variant="outline"
+              className="!h-[52px] !w-[180px] !rounded-lg !border-none !bg-white !text-[#E0B43A] hover:!bg-[#fdf7e3] hover:!text-[#C58C00]"
+              onClick={() => navigate('/signup')}
+            >
+              무료로 시작하기
+            </Button>
+            <Button
+              variant="outline"
+              className="!h-[52px] !w-[200px] !rounded-lg !border !border-white !text-white hover:!bg-white hover:!text-[#E0B43A]"
+              onClick={() => navigate('/studygroups')} // 임시경로작성
+            >
+              스터디 그룹 만들기
+            </Button>
           </div>
         </div>
       </section>

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router'
 import Button from '../components/common/Button'
 import ImageCards from '../components/common/ImageCards'
+import { Laptop, Users, GraduationCap } from 'lucide-react'
 
 function MainPage() {
   const navigate = useNavigate()
@@ -33,7 +34,7 @@ function MainPage() {
             </Button>
 
             <Button
-              onClick={() => navigate('/studygroups')} // 임시경로작성
+              onClick={() => navigate('/studygroups')} //임시경로작성
               className="!border-primary-500 !text-primary-600 hover:!bg-primary-100 !h-[48px] !w-full max-w-[300px] !rounded-[8px] !border sm:!h-[50px] sm:!w-[177px]"
             >
               스터디 그룹 참여
@@ -66,8 +67,8 @@ function MainPage() {
 
           <div className="flex flex-col items-center gap-10 sm:flex-row sm:justify-center sm:gap-16">
             <div className="flex w-full max-w-[360px] flex-col items-center text-center sm:max-w-[384px]">
-              <div className="mb-4 flex h-[64px] w-[64px] items-center justify-center rounded-full bg-yellow-100 text-2xl text-yellow-500 sm:h-[80px] sm:w-[80px] sm:text-3xl">
-                💻
+              <div className="mb-4 flex h-[64px] w-[64px] items-center justify-center rounded-full bg-yellow-100 text-yellow-500 sm:h-[80px] sm:w-[80px]">
+                <Laptop className="h-8 w-8 sm:h-10 sm:w-10" />
               </div>
               <h3 className="mb-2 text-[16px] font-semibold text-gray-900 sm:text-[18px]">
                 다양한 IT 강의
@@ -80,8 +81,8 @@ function MainPage() {
             </div>
 
             <div className="flex w-full max-w-[360px] flex-col items-center text-center sm:max-w-[384px]">
-              <div className="mb-4 flex h-[64px] w-[64px] items-center justify-center rounded-full bg-green-100 text-2xl text-green-500 sm:h-[80px] sm:w-[80px] sm:text-3xl">
-                👥
+              <div className="mb-4 flex h-[64px] w-[64px] items-center justify-center rounded-full bg-green-100 text-green-500 sm:h-[80px] sm:w-[80px]">
+                <Users className="h-8 w-8 sm:h-10 sm:w-10" />
               </div>
               <h3 className="mb-2 text-[16px] font-semibold text-gray-900 sm:text-[18px]">
                 스터디 그룹
@@ -94,8 +95,8 @@ function MainPage() {
             </div>
 
             <div className="flex w-full max-w-[360px] flex-col items-center text-center sm:max-w-[384px]">
-              <div className="mb-4 flex h-[64px] w-[64px] items-center justify-center rounded-full bg-purple-100 text-2xl text-purple-500 sm:h-[80px] sm:w-[80px] sm:text-3xl">
-                🎓
+              <div className="mb-4 flex h-[64px] w-[64px] items-center justify-center rounded-full bg-purple-100 text-purple-500 sm:h-[80px] sm:w-[80px]">
+                <GraduationCap className="h-8 w-8 sm:h-10 sm:w-10" />
               </div>
               <h3 className="mb-2 text-[16px] font-semibold text-gray-900 sm:text-[18px]">
                 전문 강사진
@@ -110,7 +111,7 @@ function MainPage() {
         </div>
       </section>
 
-      {/* 인기 강의 Section  */}
+      {/* 인기 강의 Section */}
       <section className="flex w-full flex-col items-center justify-center bg-white px-6 py-16 sm:px-8">
         <div className="w-full max-w-[1280px]">
           <div className="mb-10 flex items-end justify-between">
@@ -158,7 +159,7 @@ function MainPage() {
                 date={course.date}
                 imageUrl={course.imageUrl}
                 size="w-full sm:w-[384px] h-[17.375rem]"
-                onClick={() => navigate('/popularcourses')} // 임시경로작성
+                onClick={() => navigate('/popularcourses')} //임시경로작성
               />
             ))}
           </div>
@@ -186,7 +187,7 @@ function MainPage() {
             <Button
               variant="outline"
               className="!h-[52px] !w-[200px] !rounded-lg !border !border-white !text-white hover:!bg-white hover:!text-[#E0B43A]"
-              onClick={() => navigate('/studygroups')} // 임시경로작성
+              onClick={() => navigate('/studygroups')} //임시경로작성
             >
               스터디 그룹 만들기
             </Button>


### PR DESCRIPTION
## PR 제목

[Feat] 랜딩페이지 / 인기강의 및 CTA 섹션 UI 구현

## 관련 이슈
#55

## 변경 사항 요약

인기강의섹션 : 카드3~6개, 반응형 레이아웃 레이아웃
CTA섹션 : 핵심문구, 버튼2개, 반응형 레이아웃
아이콘이모지 -> Lucide-react 아이콘으로 수정

## 체크리스트

- [ ] 코드가 빌드되고 실행되는지 확인 (로컬에서)
- [ ] 관련 파일 및 문서 수정 여부 확인
- [ ] 리뷰 요청 내용 작성
- [ ] 코드에 불필요한 console.log & console.error 제거
- [ ] PR 제목이 규칙에 맞게 작성됨 (예: [Fix]/[Feat]/[Docs])

## 스크린샷 (선택)
<img width="2962" height="1476" alt="image" src="https://github.com/user-attachments/assets/1f5ceb1f-c110-4a31-966f-48b54aa78656" />

<img width="1076" height="1442" alt="image" src="https://github.com/user-attachments/assets/387e8501-44f0-4fc6-874c-c832967aae9f" />


## 리뷰어

- @devjaesung
- @chen4023
