### PR TITLE
[Feat] API 테스트 페이지 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import { useEffect, useState } from 'react'
 import { useToken } from './store/useTokenStore'
 import { useUserStore } from './store/useUserStore'
 import { api } from './api/client'
+import ApiTestPage from './tests/ApiTestPage'
 
 function App() {
   const [isCheck, setIsCheck] = useState(true)
@@ -35,7 +36,7 @@ function App() {
           }
         }>('/v1/auth/refresh', {}, { skipAuth: true })
 
-        setAccessToken(res.data.access_token) // data 객체 안의 access_token 사용
+        setAccessToken(res.data.access_token) // data 객체 안의 access_token 사용z
 
         // accessToken으로 user 정보 조회
         const userRes = await api.get<{
@@ -76,6 +77,7 @@ function App() {
     { path: '/login', element: <LoginPage /> },
     { path: '/signup', element: <SignUpPage /> },
     { path: '/test', element: <CommonTest /> },
+    { path: '/api-test', element: <ApiTestPage /> },
     { path: '/emailfind', element: <EmailFindPage /> },
     { path: '/passwordfind', element: <PasswordFindPage /> },
     { path: '*', element: <NotFoundPage /> },

--- a/src/api/Helper/useSimpleMutation.ts
+++ b/src/api/Helper/useSimpleMutation.ts
@@ -1,5 +1,9 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 
+// useMutation > 데이터를 변경하고, 다른 캐시를 무효화 = POST, PUT PATCH, DELETE
+// - 수동 실행 (mutate() 호출)
+// - 캐싱 안함 (일회성)
+// - invalidateKeys로 다른 쿼리 캐시 무효화
 export function useSimpleMutation<
   T = unknown,
   TError = Error,

--- a/src/api/Helper/useSimpleQuery.ts
+++ b/src/api/Helper/useSimpleQuery.ts
@@ -4,6 +4,10 @@ import {
   type UseQueryOptions,
 } from '@tanstack/react-query'
 
+// useQuery > 데이터를 가져와서 캐싱(저장) = GET
+// - 자동 실행 (컴포넌트 마운트 시)
+// - 자동 캐싱 및 재사용
+// - queryKey로 캐시 관리
 export function useSimpleQuery<T = unknown, TError = Error>(
   queryKey: QueryKey,
   queryFn: () => Promise<T>,

--- a/src/tests/ApiTestPage.tsx
+++ b/src/tests/ApiTestPage.tsx
@@ -239,10 +239,10 @@ export default function ApiTestPage() {
 {
   id: 'my-api-id', // TanStack Query의 queryKey로 사용 (캐싱 및 리페칭 식별자)
   name: 'API 이름', // 테스트 페이지에 표시될 API 이름
-  method: 'post', // HTTP 메서드 (get, post, put, delete 등)
+  method: 'post', // HTTP 메서드 (get, post, put, patch, delete)
   url: '/v1/endpoint', // API 엔드포인트 경로
-  body: { key: 'value' }, // 요청 바디 (POST, PUT일 때 사용)
-  skipAuth: false // 토큰 인증 필요시 false, 공개 API는 true
+  body: { key: 'value' }, // 요청 값 (payload)
+  skipAuth: true // 인증 요청이 필요없는 경우 true, 
 }`}
         </pre>
       </div>

--- a/src/tests/ApiTestPage.tsx
+++ b/src/tests/ApiTestPage.tsx
@@ -49,7 +49,6 @@ const API_TESTS: ApiTest[] = [
       verify_token: 'eyJhbGciOi...', // 휴대폰 변경 시에만 필수
     },
   },
-
   {
     id: 'updatePasswrod',
     name: '내정보 수정 - 비밀번호 변경',
@@ -59,6 +58,16 @@ const API_TESTS: ApiTest[] = [
       current_password: 'old',
       new_password: 'New!234',
       new_password_confirm: 'New!234',
+    },
+  },
+
+  {
+    id: 'sendEmailAuthCode',
+    name: '이메일 인증코드 전송 (이메일 변경)',
+    method: 'post',
+    url: '/v1/email-verifications/email-change/send-code',
+    body: {
+      email: 'example@example.com',
     },
   },
 ]
@@ -242,7 +251,7 @@ export default function ApiTestPage() {
   method: 'post', // HTTP 메서드 (get, post, put, patch, delete)
   url: '/v1/endpoint', // API 엔드포인트 경로
   body: { key: 'value' }, // 요청 값 (payload)
-  skipAuth: true // 인증 요청이 필요없는 경우 true, 
+  skipAuth: true // 인증 요청이 필요없는 경우 true, 필요한 경우 생략
 }`}
         </pre>
       </div>

--- a/src/tests/ApiTestPage.tsx
+++ b/src/tests/ApiTestPage.tsx
@@ -1,0 +1,240 @@
+import { useState } from 'react'
+import { api } from '../api/client'
+import { useToken } from '../store/useTokenStore'
+import { useUserStore } from '../store/useUserStore'
+import { useSimpleMutation } from '../api/Helper/useSimpleMutation'
+import Button from '../components/common/Button'
+
+interface ApiTest {
+  id: string
+  name: string
+  method: 'get' | 'post' | 'put' | 'patch' | 'delete'
+  url: string
+  body?: Record<string, unknown>
+  skipAuth?: boolean
+}
+
+// 여기다가 추가해서 테스트
+const API_TESTS: ApiTest[] = [
+  {
+    id: 'login',
+    name: '로그인',
+    method: 'post',
+    url: '/v1/auth/login',
+    body: { email: 'test@test.com', password: 'password123' },
+    skipAuth: true,
+  },
+  {
+    id: 'logout',
+    name: '로그아웃',
+    method: 'post',
+    url: '/v1/auth/logout',
+  },
+
+  {
+    id: 'getUserMe',
+    name: '내 정보 조회',
+    method: 'get',
+    url: '/v1/me',
+  },
+  {
+    id: 'updateProfile',
+    name: '내정보 수정 - 일반정보수정',
+    method: 'patch',
+    url: '/v1/users/me',
+    body: {
+      nickname: 'ozdev2',
+      profile_image_url: 'https://cdn.example.com/u/ozdev2.png',
+      phone_number: '01012345678',
+      verify_token: 'eyJhbGciOi...', // 휴대폰 변경 시에만 필수
+    },
+  },
+]
+
+export default function ApiTestPage() {
+  const [selectedId, setSelectedId] = useState<string>('')
+  const { accessToken, setAccessToken } = useToken()
+  const { user, setUser } = useUserStore()
+
+  // 더미 로그인
+  const handleMockLogin = () => {
+    const token = 'access_token_' + Date.now()
+    setAccessToken(token)
+    setUser({ id: 1, email: 'test@test.com', nickname: '테스트' })
+  }
+
+  // api 테스트 Mutation
+  const testMutation = useSimpleMutation<unknown, Error, ApiTest>(
+    async (test: ApiTest) => {
+      const config = test.skipAuth ? { skipAuth: true as const } : {}
+
+      switch (test.method) {
+        case 'get':
+          return await api.get(test.url, config)
+        case 'post':
+          return await api.post(test.url, test.body || {}, config)
+        case 'put':
+          return await api.put(test.url, test.body || {}, config)
+        case 'patch':
+          return await api.patch(test.url, test.body || {}, config)
+        case 'delete':
+          return await api.delete(test.url, config)
+      }
+    },
+    {
+      onSuccess: (data, variables) => {
+        console.log('성공:', variables.name)
+        console.log('Response:', data)
+      },
+      onError: (error) => {
+        // variables가 undefined일 수 있으므로 optional chaining 사용
+        console.error(`실패`)
+        console.error('Error:', error)
+      },
+    }
+  )
+
+  const selectedTest = API_TESTS.find((t) => t.id === selectedId)
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-6 p-6">
+      {/* 제목 */}
+      <div>
+        <h1 className="text-2xl font-bold">API 테스트</h1>
+        <p className="mt-1 text-sm text-gray-600">
+          F12 → Network 탭에서 요청 확인
+        </p>
+      </div>
+
+      {/* 현재 상태 */}
+      <div className="rounded-lg bg-gray-50 p-4">
+        <h3 className="mb-2 font-semibold">현재 상태</h3>
+        <div className="space-y-1 text-sm">
+          <p>
+            <span className="font-medium">accessToken:</span>{' '}
+            <span className="font-mono text-xs break-all">
+              {accessToken || '없음'}
+            </span>
+          </p>
+          <p className="mb-4">
+            <span className="font-medium">user:</span>{' '}
+            <span className="font-mono text-xs">
+              {user ? user.nickname : '없음'}
+            </span>
+          </p>
+        </div>
+        <Button variant="primary" onClick={handleMockLogin} size="freeWidthMd">
+          더미 로그인 (테스트용)
+        </Button>
+      </div>
+
+      {/* API 선택 */}
+      <div className="rounded-lg border bg-white p-4">
+        <h3 className="mb-3 font-semibold">API 선택</h3>
+        <div className="grid grid-cols-2 gap-2">
+          {API_TESTS.map((test) => (
+            <button
+              key={test.id}
+              onClick={() => setSelectedId(test.id)}
+              className={`rounded-lg border p-3 text-left transition-all ${
+                selectedId === test.id
+                  ? 'border-primary-500 bg-primary-100'
+                  : 'hover:bg-gray-50'
+              }`}
+            >
+              <div className="text-sm font-medium">{test.name}</div>
+              <div className="mt-1 text-xs text-gray-500">
+                <span className="rounded bg-gray-100 px-1.5 py-0.5 font-mono">
+                  {test.method.toUpperCase()}
+                </span>{' '}
+                {test.url}
+              </div>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* 선택된 api 상세 */}
+      {selectedTest && (
+        <div className="space-y-3 rounded-lg border bg-white p-4">
+          <h3 className="font-semibold">{selectedTest.name}</h3>
+
+          <div className="space-y-2 text-sm">
+            <div>
+              <span className="font-medium">Method:</span>{' '}
+              <span className="font-mono">
+                {selectedTest.method.toUpperCase()}
+              </span>
+            </div>
+            <div>
+              <span className="font-medium">URL:</span>{' '}
+              <span className="font-mono text-xs">{selectedTest.url}</span>
+            </div>
+            {selectedTest.body && (
+              <div>
+                <span className="font-medium">Body:</span>
+                <pre className="mt-1 overflow-x-auto rounded bg-gray-50 p-2 font-mono text-xs">
+                  {JSON.stringify(selectedTest.body, null, 2)}
+                </pre>
+              </div>
+            )}
+            <div>
+              <span className="font-medium">Authorization:</span>{' '}
+              <span
+                className={
+                  selectedTest.skipAuth ? 'text-danger-600' : 'text-success-600'
+                }
+              >
+                {selectedTest.skipAuth ? '없음' : 'Bearer 토큰 포함'}
+              </span>
+            </div>
+          </div>
+
+          <Button
+            variant="primary"
+            onClick={() => testMutation.mutate(selectedTest)}
+            size="freeWidthMd"
+            disabled={testMutation.isPending}
+          >
+            {testMutation.isPending ? '실행중..' : '실행하기'}
+          </Button>
+        </div>
+      )}
+
+      {/* 안내 */}
+      <div className="rounded-lg border border-gray-200 bg-gray-50 p-4">
+        <h3 className="mb-2 text-sm font-semibold">확인 방법</h3>
+        <ol className="list-inside list-decimal space-y-1 text-sm text-gray-700">
+          <li>더미 로그인으로 토큰 생성</li>
+          <li>테스트할 API 선택</li>
+          <li>실행하기 버튼 클릭</li>
+          <li>
+            <span className="font-medium">F12 → Network 탭</span>에서 요청 확인
+          </li>
+          <li>
+            <span className="font-medium">Headers</span>에서 Authorization 확인
+          </li>
+          <li>
+            <span className="font-medium">Payload</span>에서 요청 값 확인
+          </li>
+        </ol>
+      </div>
+
+      {/* API 추가 가이드 */}
+      <div className="rounded-lg bg-gray-50 p-4">
+        <h3 className="mb-2 text-sm font-semibold">API 추가 방법</h3>
+        <pre className="text-success-500 overflow-x-auto rounded-md bg-black p-3 text-xs">
+          {`// API_TESTS 배열에 추가
+{
+  id: 'my-api',
+  name: '내 API 이름',
+  method: 'post',
+  url: '/v1/my/endpoint',
+  body: { key: 'value' },
+  skipAuth: false // 토큰 필요시 false
+}`}
+        </pre>
+      </div>
+    </div>
+  )
+}

--- a/src/tests/ApiTestPage.tsx
+++ b/src/tests/ApiTestPage.tsx
@@ -106,11 +106,32 @@ export default function ApiTestPage() {
       onSuccess: (data, variables) => {
         console.log('성공:', variables.name)
         console.log('Response:', data)
+
+        // 실제 사용 예시
+        // showToast('로그인 성공', 'success', '로그인이 완료되었습니다')
+        // setAccessToken(data.access_token)
+        // navigate('/')
       },
       onError: (error) => {
         console.error(`실패`)
         console.error('Error:', error)
+
+        // onError: API 요청이 실패했을 때 실행되는 콜백
+        // 주로 사용하는 경우
+        // - 에러 토스트 메시지 표시
+        // - 에러 로깅
+        // - 특정 에러에 따른 처리 (401 → 로그인 페이지 이동)
+        // - 폼 에러 상태 업데이트
+        // showToast('로그인 실패', 'error', error)
       },
+
+      // invalidateKeys: 성공 후 자동으로 갱신할 쿼리 키 목록
+      // 예시 : 리뷰 작성 후 리뷰 새로고침
+      // invalidateKeys: ['/v1/reviews'],
+
+      // removeKeys: 성공 후 캐시에서 제거할 쿼리 키 목록
+      // 예 : 로그아웃 후 유저 정보 캐시 삭제
+      // removeKeys: ['/v1/me'],
     }
   )
 
@@ -246,11 +267,11 @@ export default function ApiTestPage() {
         <pre className="text-success-500 overflow-x-auto rounded-md bg-black p-3 text-xs">
           {`// API_TESTS 배열에 추가
 {
-  id: 'my-api-id', // TanStack Query의 queryKey로 사용 (캐싱 및 리페칭 식별자)
-  name: 'API 이름', // 테스트 페이지에 표시될 API 이름
+  id: 'my-api-id', // 테스트 페이지 내부 id
+  name: 'API 이름', // 화면에 표시될 이름
   method: 'post', // HTTP 메서드 (get, post, put, patch, delete)
-  url: '/v1/endpoint', // API 엔드포인트 경로
-  body: { key: 'value' }, // 요청 값 (payload)
+  url: '/v1/endpoint', // API 엔드포인트
+  body: { key: 'value' }, // 요청 BODY => 값 (payload)
   skipAuth: true // 인증 요청이 필요없는 경우 true, 필요한 경우 생략
 }`}
         </pre>

--- a/src/tests/ApiTestPage.tsx
+++ b/src/tests/ApiTestPage.tsx
@@ -41,7 +41,7 @@ const API_TESTS: ApiTest[] = [
     id: 'updateProfile',
     name: '내정보 수정 - 일반정보수정',
     method: 'patch',
-    url: '/v1/users/me',
+    url: '/v1/me',
     body: {
       nickname: 'ozdev2',
       profile_image_url: 'https://cdn.example.com/u/ozdev2.png',

--- a/src/tests/ApiTestPage.tsx
+++ b/src/tests/ApiTestPage.tsx
@@ -49,6 +49,18 @@ const API_TESTS: ApiTest[] = [
       verify_token: 'eyJhbGciOi...', // 휴대폰 변경 시에만 필수
     },
   },
+
+  {
+    id: 'updatePasswrod',
+    name: '내정보 수정 - 비밀번호 변경',
+    method: 'patch',
+    url: '/v1/me/password',
+    body: {
+      current_password: 'old',
+      new_password: 'New!234',
+      new_password_confirm: 'New!234',
+    },
+  },
 ]
 
 export default function ApiTestPage() {
@@ -87,7 +99,6 @@ export default function ApiTestPage() {
         console.log('Response:', data)
       },
       onError: (error) => {
-        // variables가 undefined일 수 있으므로 optional chaining 사용
         console.error(`실패`)
         console.error('Error:', error)
       },
@@ -102,7 +113,7 @@ export default function ApiTestPage() {
       <div>
         <h1 className="text-2xl font-bold">API 테스트</h1>
         <p className="mt-1 text-sm text-gray-600">
-          F12 → Network 탭에서 요청 확인
+          F12 - Network 탭에서 요청 확인
         </p>
       </div>
 
@@ -209,7 +220,7 @@ export default function ApiTestPage() {
           <li>테스트할 API 선택</li>
           <li>실행하기 버튼 클릭</li>
           <li>
-            <span className="font-medium">F12 → Network 탭</span>에서 요청 확인
+            <span className="font-medium">F12 - Network 탭</span>에서 요청 확인
           </li>
           <li>
             <span className="font-medium">Headers</span>에서 Authorization 확인
@@ -226,12 +237,12 @@ export default function ApiTestPage() {
         <pre className="text-success-500 overflow-x-auto rounded-md bg-black p-3 text-xs">
           {`// API_TESTS 배열에 추가
 {
-  id: 'my-api',
-  name: '내 API 이름',
-  method: 'post',
-  url: '/v1/my/endpoint',
-  body: { key: 'value' },
-  skipAuth: false // 토큰 필요시 false
+  id: 'my-api-id', // TanStack Query의 queryKey로 사용 (캐싱 및 리페칭 식별자)
+  name: 'API 이름', // 테스트 페이지에 표시될 API 이름
+  method: 'post', // HTTP 메서드 (get, post, put, delete 등)
+  url: '/v1/endpoint', // API 엔드포인트 경로
+  body: { key: 'value' }, // 요청 바디 (POST, PUT일 때 사용)
+  skipAuth: false // 토큰 인증 필요시 false, 공개 API는 true
 }`}
         </pre>
       </div>

--- a/src/utils/showToast.tsx
+++ b/src/utils/showToast.tsx
@@ -1,5 +1,5 @@
 import { toast } from 'sonner'
-import Toast from '../../components/common/toast/Toast'
+import Toast from '../components/common/toast/Toast'
 
 export const showToast = (
   message: string,


### PR DESCRIPTION
## PR 제목

<!-- 예: [Feat] 로그인 UI 구현 -->
- [Feat] API 테스트 페이지 추가
## 관련 이슈

<!-- 예: closes #123 -->
- closes #88 
## 변경 사항 요약

<!-- 변경된 내용을 간단히 작성해주세요 -->
- 테스트 페이지 추가 (아직 로그인은 더미데이터, 추후에 API 나오면 여기서 테스트 하고 실제 페이지에서 적용)
- 현재는 인증요청때 Baerer 토큰값 넣는방법, 탠스텍쿼리 useSimpleMutation 사용법만 숙지
- useQuery > 데이터를 가져와서 캐싱(저장) = GET
- useMutation > 데이터를 변경하고, 다른 캐시를 무효화 = POST, PUT PATCH, DELETE
## 체크리스트

- [ ] 코드가 빌드되고 실행되는지 확인 (로컬에서)
- [ ] 관련 파일 및 문서 수정 여부 확인
- [ ] 리뷰 요청 내용 작성
- [ ] 코드에 불필요한 console.log & console.error 제거
- [ ] PR 제목이 규칙에 맞게 작성됨 (예: [Fix]/[Feat]/[Docs])

## 스크린샷 (선택)

<!-- 스샷 보여주고 싶으면 첨부 -->
<img width="1304" height="887" alt="image" src="https://github.com/user-attachments/assets/beddd610-a42c-451e-9c7a-9f09cf333ecd" />


## 리뷰어

- @devjaesung
- @chen4023
