### PR TITLE
[Refactor] 마이페이지 > 내정보 리펙토링, 프로필이미지 업로드 추가

### DIFF
--- a/src/components/common/Avatar.tsx
+++ b/src/components/common/Avatar.tsx
@@ -1,7 +1,7 @@
 import { User } from 'lucide-react'
 import { type HTMLAttributes } from 'react'
 
-type AvatarSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+type AvatarSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl'
 
 interface AvatarProps extends HTMLAttributes<HTMLDivElement> {
   name: string
@@ -19,6 +19,17 @@ const sizeStyles: Record<AvatarSize, string> = {
   md: 'w-10 h-10 text-base',
   lg: 'w-12 h-12 text-lg',
   xl: 'w-16 h-16 text-xl',
+  '2xl': 'w-32 h-32 text-4xl ',
+}
+
+// 텍스트 크기 (이미지 없을 때)
+const textSizeStyles: Record<AvatarSize, string> = {
+  xs: 'text-xs',
+  sm: 'text-sm',
+  md: 'text-base',
+  lg: 'text-lg',
+  xl: 'text-xl',
+  '2xl': 'text-4xl',
 }
 
 export default function Avatar({
@@ -29,19 +40,20 @@ export default function Avatar({
   isHeader = false,
   ...rest
 }: AvatarProps) {
-  const sizeClass = sizeStyles[size]
+  const containerClass = sizeStyles[size]
+  const textClass = textSizeStyles[size]
 
   // 헤더인 경우 아이콘으로 대체
   if (isHeader) {
     return (
-      <div className={`${baseStyles} ${sizeClass} ${className}`} {...rest}>
+      <div className={`${baseStyles} ${containerClass} ${className}`} {...rest}>
         <User className="text-primary-500" size={20} />
       </div>
     )
   }
 
   return (
-    <div className={`${baseStyles} ${sizeClass} ${className}`} {...rest}>
+    <div className={`${baseStyles} ${containerClass} ${className}`} {...rest}>
       {imgUrl ? (
         <img
           src={imgUrl}
@@ -49,7 +61,7 @@ export default function Avatar({
           className="h-full w-full rounded-full object-cover"
         />
       ) : (
-        <span>{name.charAt(0)}</span>
+        <span className={textClass}>{name.charAt(0)}</span>
       )}
     </div>
   )

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -9,6 +9,9 @@ type ButtonVariant =
   | 'text'
   | 'signup'
   | 'login'
+  | 'success'
+  | 'gray'
+
 type ButtonSize =
   | 'md'
   | 'sm'
@@ -44,6 +47,9 @@ const variantStyles: Record<ButtonVariant, string> = {
     'text-primary-600 bg-primary-100 hover:bg-primary-200 active:bg-primary-300 disabled:text-gray-800 disabled:bg-gray-300',
   login:
     'bg-secondary-200 hover:bg-secondary-300 active:bg-secondary-400 disabled:bg-secondary-200 text-[#303030]',
+  success:
+    'bg-success-500 text-white hover:bg-success-600 active:bg-success-800 disabled:bg-success-500',
+  gray: 'bg-gray-500 text-white hover:bg-gray-600 active:bg-gary-800 disabled:bg-gray-500',
 }
 
 const sizeStyles: Record<ButtonSize, string> = {
@@ -72,7 +78,7 @@ function Button({
     <button
       type={type}
       disabled={disabled}
-      className={`${baseStyles} ${variantClass} ${sizeClass}`}
+      className={`${baseStyles} ${variantClass} ${sizeClass} `}
       {...rest}
     >
       {/* 아이콘이 있으면 왼쪽 */}

--- a/src/components/common/dropDown.tsx
+++ b/src/components/common/dropDown.tsx
@@ -94,7 +94,7 @@ export function DropDown({
           }`}
         >
           <p
-            className={`text-sm font-light ${dropDownState ? 'text-black' : 'text-gray-500'}`}
+            className={`text-sm font-light ${dropDownState ? 'text-black' : 'text-gray-700'}`}
           >
             {selectedOption || placeholder}
           </p>

--- a/src/components/mypage/PasswordChangeModal.tsx
+++ b/src/components/mypage/PasswordChangeModal.tsx
@@ -2,8 +2,7 @@ import { useState } from 'react'
 import Modal from '../common/Modal'
 import Button from '../common/Button'
 import InputWithLabel from '../common/InputWithLabel'
-import { toast } from 'sonner'
-import Toast from '../common/toast/Toast'
+import { showToast } from '../../utils/showToast'
 
 interface PasswordChangeModalProps {
   isOpen: boolean
@@ -96,15 +95,11 @@ function PasswordChangeModal({ isOpen, onClose }: PasswordChangeModalProps) {
 
     if (!isCurrentValid || !isNewValid || !isConfirmValid) return
 
-    // 성공
-    toast.custom((t) => (
-      <Toast
-        id={t}
-        title="비밀번호 변경 완료"
-        message="비밀번호가 성공적으로 변경되었습니다"
-        type="success"
-      />
-    ))
+    showToast(
+      '비밀번호가 성공적으로 변경되었습니다',
+      'success',
+      '비밀번호 변경 완료'
+    )
 
     handleCancel()
   }

--- a/src/components/mypage/ProfileContents.tsx
+++ b/src/components/mypage/ProfileContents.tsx
@@ -20,7 +20,8 @@ function ProfileContents() {
     name: '김개발',
     phone_number: phoneFormat('01012345678'),
     birthday: birthdayFormat('1998-01-23'),
-    profile_image_url: 'https://cdn.example.com/u/1.png',
+    profile_image_url:
+      'https://images.unsplash.com/photo-1633356122544-f134324a6cee?w=400&h=300&fit=crop',
     created_at: '2025-01-01T10:00:00Z',
   })
 
@@ -59,8 +60,8 @@ function ProfileContents() {
         <div className="flex flex-col items-center gap-4">
           <Avatar
             name={formData.name}
-            size="xl"
-            className="h-32 w-32 !text-4xl"
+            size="2xl"
+            imgUrl={formData.profile_image_url}
           />
           <p className="text-center text-lg font-semibold text-gray-900">
             프로필 이미지
@@ -94,7 +95,7 @@ function ProfileContents() {
             </p>
           </div>
           <Button
-            variant="secondary"
+            variant="gray"
             size="md"
             onClick={() => setIsPasswordModalOpen(true)}
           >
@@ -139,6 +140,7 @@ function ProfileContents() {
         onClose={() => setIsPasswordModalOpen(false)}
       />
 
+      {/* 회원탈퇴 모달 */}
       <UserLeaveModal
         isOpen={isWithdrawalModalOpen}
         onClose={() => setIsWithdrawalModalOpen(false)}

--- a/src/components/mypage/ProfileEditModal.tsx
+++ b/src/components/mypage/ProfileEditModal.tsx
@@ -1,12 +1,11 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import Avatar from '../common/Avatar'
 import Button from '../common/Button'
 import InputWithLabel from '../common/InputWithLabel'
 import Modal from '../common/Modal'
 import { phoneFormat } from '../../utils/phoneFormat'
-import { toast } from 'sonner'
-import Toast from '../common/toast/Toast'
 import type { UserProfileData } from '../../types/userType'
+import { showToast } from '../../utils/showToast'
 
 interface ProfileEditModalProps {
   isOpen: boolean
@@ -21,10 +20,13 @@ function ProfileEditModal({
   onClose,
   onSave,
 }: ProfileEditModalProps) {
-  const [tempData, setTempData] = useState<UserProfileData>(profileData)
-  const [showVerificationInput, setShowVerificationInput] = useState(false)
-  const [verificationCode, setVerificationCode] = useState('')
-  const [isVerified, setIsVerified] = useState(false)
+  const [tempData, setTempData] = useState<UserProfileData>(profileData) //모달에서 수정 중인 프로필 데이터
+  const [showVerificationInput, setShowVerificationInput] = useState(false) // 휴대폰 인증번호 입력창 표시 여부
+  const [verificationCode, setVerificationCode] = useState('') // 인증번호
+  const [isVerified, setIsVerified] = useState(false) //인증번호 확인 완료 여부
+  const [previewImage, setPreviewImage] = useState<string | null>(null) //선택한 이미지의 미리보기 url (FileReader로 생성한 base64)
+  const [_selectedFile, setSelectedFile] = useState<File | null>(null) // 선택한 이미지 파일 객체
+  const fileInputRef = useRef<HTMLInputElement>(null) // 숨겨진 file input 요소에 접근하기 위한 ref
 
   const DUMMY_VERIFICATION_CODE = '123456'
 
@@ -39,10 +41,58 @@ function ProfileEditModal({
     }))
   }
 
-  const handleSave = () => {
+  // 파일 선택 핸들러
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+
+    if (!file) return
+
+    // 이미지 파일만 허용
+    const imageMimeType = /image\/(png|jpg|jpeg|webp)/i
+    if (!file.type.match(imageMimeType)) {
+      showToast(
+        '이미지 파일만 업로드 가능합니다 (png, jpg, jpeg, webp)',
+        'error',
+        '업로드 실패'
+      )
+      return
+    }
+
+    // 파일 크기 제한 (5MB)
+    const maxSize = 5 * 1024 * 1024 // 5MB
+    if (file.size > maxSize) {
+      showToast('파일 크기는 5MB 이하여야 합니다', 'error', '업로드 실패')
+      return
+    }
+
+    setSelectedFile(file)
+
+    // FileReader로 미리보기 생성
+    const reader = new FileReader()
+    reader.onload = (e) => {
+      const result = e.target?.result as string
+      setPreviewImage(result)
+    }
+    reader.readAsDataURL(file)
+  }
+
+  // 프로필 사진 변경 버튼 클릭
+  const handleProfileImageClick = () => {
+    fileInputRef.current?.click()
+  }
+
+  const handleSave = async () => {
+    // 나중에 api 연결할떄 여기서 S3 presigned URL 받아서 업로드
+    // 현재는 미리보기 이미지를 그대로 사용 (로컬 blob URL)
+    if (previewImage) {
+      tempData.profile_image_url = previewImage
+    }
+
     onSave(tempData)
     setShowVerificationInput(false)
     setVerificationCode('')
+    setPreviewImage(null)
+    setSelectedFile(null)
   }
 
   const handleCancel = () => {
@@ -50,20 +100,14 @@ function ProfileEditModal({
     setShowVerificationInput(false)
     setVerificationCode('')
     setIsVerified(false)
+    setPreviewImage(null)
+    setSelectedFile(null)
     onClose()
   }
 
   const handleVerificationClick = () => {
     setShowVerificationInput(true)
-
-    toast.custom((t) => (
-      <Toast
-        id={t}
-        title="인증번호 전송"
-        message="인증 번호가 전송되었습니다"
-        type="success"
-      />
-    ))
+    showToast('인증 번호가 전송되었습니다', 'success', '인증번호 전송')
   }
 
   const handleVerificationChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -75,28 +119,17 @@ function ProfileEditModal({
   const handleVerificationConfirm = () => {
     if (verificationCode === DUMMY_VERIFICATION_CODE) {
       setIsVerified(true)
-      toast.custom((t) => (
-        <Toast
-          id={t}
-          title="인증 완료"
-          message="인증이 완료되었습니다"
-          type="success"
-        />
-      ))
+      showToast('인증이 완료되었습니다', 'success', '인증 완료')
     } else {
-      toast.custom((t) => (
-        <Toast
-          id={t}
-          title="인증 실패"
-          message="인증 번호를 확인하세요"
-          type="error"
-        />
-      ))
+      showToast('인증 번호를 확인하세요', 'error', '인증 실패')
     }
   }
 
   // 변경하기 버튼 비활성화 (인증 입력창이 보이지만 인증이 완료되지 않은 경우)
   const isSaveDisabled = showVerificationInput && !isVerified
+
+  // 표시할 이미지: 미리보기 > 기존 프로필 이미지
+  const displayImage = previewImage || tempData.profile_image_url
 
   return (
     <Modal
@@ -122,10 +155,22 @@ function ProfileEditModal({
       <div className="flex flex-col items-center gap-6">
         {/* 프로필 이미지 */}
         <div className="flex flex-col items-center gap-2">
-          <Avatar name={tempData.name} size="xl" />
-          <p className="text-primary-600 hover:text-primary-700 cursor-pointer text-sm">
+          <Avatar name={tempData.name} size="xl" imgUrl={displayImage} />
+          <button
+            type="button"
+            onClick={handleProfileImageClick}
+            className="text-primary-600 hover:text-primary-700 cursor-pointer text-sm transition-colors"
+          >
             프로필 사진 변경
-          </p>
+          </button>
+          {/* 숨겨진 파일 입력 */}
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/png, image/jpeg, image/jpg, image/webp"
+            onChange={handleFileChange}
+            className="hidden"
+          />
         </div>
 
         {/* 입력 필드들 */}

--- a/src/components/mypage/StudyDetailModal.tsx
+++ b/src/components/mypage/StudyDetailModal.tsx
@@ -151,9 +151,7 @@ function StudyDetailModal({
             <p className="mb-2 text-sm font-medium text-gray-700">
               스터디 경험
             </p>
-            <div
-              className={`rounded-lg p-4 ${applicationDetail.study_experience ? 'bg-green-50' : 'bg-gray-50'}`}
-            >
+            <div className="p-4">
               <Badge
                 variant={
                   applicationDetail.study_experience ? 'success' : 'danger'

--- a/src/components/mypage/UserLeaveModal.tsx
+++ b/src/components/mypage/UserLeaveModal.tsx
@@ -2,10 +2,9 @@ import { useState } from 'react'
 import Modal from '../common/Modal'
 import Button from '../common/Button'
 import { AlertCircle } from 'lucide-react'
-import { toast } from 'sonner'
-import Toast from '../common/toast/Toast'
 import { useNavigate } from 'react-router'
 import { DropDown } from '../common/dropDown'
+import { showToast } from '../../utils/showToast'
 
 interface UserLeaveModalProps {
   isOpen: boolean
@@ -29,25 +28,11 @@ function UserLeaveModal({ isOpen, onClose }: UserLeaveModalProps) {
 
   const handleSubmit = () => {
     if (!selectedReason || !detailReason || !isChecked) {
-      toast.custom((t) => (
-        <Toast
-          id={t}
-          title="회원탈퇴 실패"
-          message="모든 항목을 입력해주세요"
-          type="error"
-        />
-      ))
+      showToast('모든 항목을 입력해주세요', 'error', '회원탈퇴 실패')
       return
     }
 
-    toast.custom((t) => (
-      <Toast
-        id={t}
-        title="회원탈퇴 성공"
-        message="이용해주셔서 감사합니다"
-        type="success"
-      />
-    ))
+    showToast('이용해주셔서 감사합니다', 'success', '회원탈퇴 성공')
     navigate('/')
     onClose()
   }

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -1,4 +1,4 @@
-import { useLocation } from 'react-router'
+import { useLocation, useNavigate } from 'react-router'
 import MyPageSideBar from '../components/mypage/MyPageSideBar'
 import ProfileContents from '../components/mypage/ProfileContents'
 import JobsContents from '../components/mypage/JobsContents'
@@ -6,12 +6,21 @@ import { MYPAGE_MENU_ITEMS } from '../constants/myPageMenu'
 import CourseContents from '../components/mypage/CourseContents'
 import StudysContents from '../components/mypage/StudysContents'
 import CompletedStudyContents from '../components/mypage/CompletedStudyContents'
+import { useEffect } from 'react'
 
 function MyPage() {
   const location = useLocation()
+  const navigate = useNavigate()
 
   // 현재 경로 기반으로 활성 탭 결정 (기본값: profile)
   const currentActive = location.pathname.split('/mypage/')[1] ?? 'profile'
+
+  // /mypage로 접근 시 /mypage/profile로 리다이렉트
+  useEffect(() => {
+    if (location.pathname === '/mypage' || location.pathname === '/mypage/') {
+      navigate('/mypage/profile', { replace: true })
+    }
+  }, [location.pathname, navigate])
 
   const renderContent = () => {
     switch (currentActive) {


### PR DESCRIPTION
## PR 제목

<!-- 예: [Feat] 로그인 UI 구현 -->
- [Refactor] 마이페이지 > 내정보 리펙토링, 프로필이미지 업로드 추가
## 관련 이슈

<!-- 예: closes #123 -->
- closes #109
## 변경 사항 요약

<!-- 변경된 내용을 간단히 작성해주세요 -->
- Avatar 컴포넌트 2xl 추가 (내정보 프로필 이미지 없을때 글자크기 대응)
- Button 컴포넌트 variant: gray 추가 (비밀번호 변경 버튼색 대응), success 추가
- 내정보 변경 > 프로필변경 파일업로드, 미리보기 추가
- showToast로 변경
- /mypage로 접근시 /mypage/profile로 자동 리다이렉션 추가
- 마이페이지 왼쪽 사이드바 정보는 api 연결 후 전역상태로 대체할 예정이라 그냥 놔둠
## 체크리스트

- [x] 코드가 빌드되고 실행되는지 확인 (로컬에서)
- [x] 관련 파일 및 문서 수정 여부 확인
- [x] 리뷰 요청 내용 작성
- [x] 코드에 불필요한 console.log & console.error 제거
- [x] PR 제목이 규칙에 맞게 작성됨 (예: [Fix]/[Feat]/[Docs])

## 스크린샷 (선택)

<!-- 스샷 보여주고 싶으면 첨부 -->

## 리뷰어

- @devjaesung
- @chen4023
