### PR TITLE
[Refactor] 북마크 공고/강의 리펙토링 및 로딩 스켈레톤으로 변경

### DIFF
--- a/src/components/mypage/BookmarkCard.tsx
+++ b/src/components/mypage/BookmarkCard.tsx
@@ -1,84 +1,101 @@
 import Button from '../common/Button'
 import Badge from '../common/Badge'
 import { User, Calendar, Eye, Bookmark, Clock } from 'lucide-react'
+import type {
+  LectureBookmark,
+  StudyJobs,
+} from '../../types/apiInterface/mypageInterface'
 
-// 강의 정보 타입
-interface LectureInfo {
-  uuid: string
-  title: string
-  instructor: string
-  thumbnail_img_url: string
-  platform: string
-  description: string
-  difficulty: 'BEGINNER' | 'NORMAL' | 'ADVANCED'
-  duration: string
-  original_price: number
-  discount_price: number
-  average_rating: number
-  url_link: string
-}
-
-// 공고 > 강의 타입
-interface Course {
-  name: string
-  instructor: string
-}
-
-// 공고용 타입
-interface JobBookmarkData {
-  type: 'job'
-  id: number
-  uuid: string
-  title: string
-  introduction: string
-  thumbnail: string
-  max_headcount: number
-  start_at: string
-  end_at: string
-  status: 'PENDING' | 'ACTIVE' | 'CLOSED'
-  courses: Course[]
-  tags: string[]
-  views: number
-  bookmark_count: number
-  bookmarked_at: string
-}
-
-// 강의용 타입
-interface CourseBookmarkData {
-  type: 'course'
-  id: number
-  lecture_info: LectureInfo
-  created_at: string
-}
-
-type BookmarkData = JobBookmarkData | CourseBookmarkData
-
-interface BookmarkCardProps {
-  data: BookmarkData
-  onBookmarkToggle: (id: number) => void
+interface JobBookmarkCardProps {
+  data?: StudyJobs
+  onBookmarkToggle?: (id: number) => void
   onViewClick?: (id: number) => void
+  isLoading?: boolean
+}
+
+interface CourseBookmarkCardProps {
+  data?: LectureBookmark
+  onBookmarkToggle?: (id: number) => void
+  onViewClick?: (id: number) => void
+  isLoading?: boolean
 }
 
 // 공고 카드
-function JobBookmarkCard({
+export function JobBookmarkCard({
   data,
   onBookmarkToggle,
   onViewClick,
-}: {
-  data: JobBookmarkData
-  onBookmarkToggle: (id: number) => void
-  onViewClick?: (id: number) => void
-}) {
+  isLoading,
+}: JobBookmarkCardProps) {
+  if (isLoading) {
+    return (
+      <div className="animate-pulse rounded-lg border border-gray-200 bg-white p-6">
+        <div className="flex gap-4">
+          {/*이미지 스켈레톤 */}
+          <div className="flex h-auto min-w-40 items-center rounded-lg">
+            <div className="h-24 w-full rounded-lg bg-gray-200" />
+          </div>
+
+          {/* 컨텐츠 스켈레톤 */}
+          <div className="flex flex-1 flex-col">
+            {/* 타이틀 */}
+            <div className="mb-2">
+              <div className="h-6 w-3/4 rounded bg-gray-200" />
+            </div>
+
+            {/* 메타 정보 */}
+            <div className="mb-3 flex gap-4">
+              <div className="h-4 w-24 rounded bg-gray-200" />
+              <div className="h-4 w-32 rounded bg-gray-200" />
+              <div className="h-4 w-16 rounded bg-gray-200" />
+              <div className="h-4 w-20 rounded bg-gray-200" />
+            </div>
+
+            {/* 강의 목록 */}
+            <div className="mb-3 space-y-2">
+              <div className="h-4 w-20 rounded bg-gray-200" />
+              <div className="h-4 w-48 rounded bg-gray-200" />
+              <div className="h-4 w-44 rounded bg-gray-200" />
+            </div>
+
+            {/* 태그 */}
+            <div className="flex gap-2">
+              <div className="h-6 w-16 rounded bg-gray-200" />
+              <div className="h-6 w-20 rounded bg-gray-200" />
+              <div className="h-6 w-24 rounded bg-gray-200" />
+            </div>
+          </div>
+
+          {/* 버튼 스켈레톤 - 실제와 동일한 구조 */}
+          <div className="flex flex-shrink-0 flex-col items-start gap-2">
+            <div className="flex items-center gap-4">
+              <div className="h-5 w-5 rounded bg-gray-200" />
+              <div className="h-10 w-24 rounded bg-gray-200" />
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  if (!data) return
+
   return (
     <div className="rounded-lg border border-gray-200 bg-white p-6 transition-shadow hover:shadow-md">
       <div className="flex gap-4">
         {/* 이미지 */}
-        <div className="flex h-auto max-w-36 flex-shrink-0 items-center">
-          <img
-            src={data.thumbnail}
-            alt={data.title}
-            className="max-h-24 w-full rounded-lg object-cover"
-          />
+        <div className="flex h-auto min-w-40 items-center rounded-lg">
+          {data.thumbnail ? (
+            <img
+              src={data.thumbnail}
+              alt={data.title}
+              className="h-24 w-full object-cover"
+            />
+          ) : (
+            <div className="flex h-24 w-full items-center justify-center bg-gray-200 text-gray-400">
+              Image
+            </div>
+          )}
         </div>
 
         {/* 컨텐츠 */}
@@ -136,7 +153,7 @@ function JobBookmarkCard({
         <div className="flex flex-shrink-0 flex-col items-start gap-2">
           <div className="flex items-center gap-4">
             <button
-              onClick={() => onBookmarkToggle(data.id)}
+              onClick={() => onBookmarkToggle?.(data.id)}
               className="cursor-pointer transition-transform hover:scale-110"
             >
               <Bookmark className="fill-primary-500 text-primary-500 h-5 w-5" />
@@ -156,25 +173,71 @@ function JobBookmarkCard({
 }
 
 // 강의 카드
-function CourseBookmarkCard({
+export function CourseBookmarkCard({
   data,
   onBookmarkToggle,
   onViewClick,
-}: {
-  data: CourseBookmarkData
-  onBookmarkToggle: (id: number) => void
-  onViewClick?: (id: number) => void
-}) {
+  isLoading,
+}: CourseBookmarkCardProps) {
+  if (isLoading) {
+    return (
+      <div className="animate-pulse rounded-xl border border-gray-200 bg-white p-6">
+        <div className="flex gap-4">
+          {/*이미지 스켈레톤 */}
+          <div className="flex h-auto min-w-40 items-center rounded-lg">
+            <div className="h-24 w-full rounded-lg bg-gray-200" />
+          </div>
+
+          {/* 컨텐츠 스켈레톤 */}
+          <div className="flex flex-1 flex-col">
+            {/* 타이틀 */}
+            <div className="mb-2">
+              <div className="mb-1 h-6 w-3/4 rounded bg-gray-200" />
+              <div className="h-4 w-1/3 rounded bg-gray-200" />
+            </div>
+
+            {/* 플랫폼, 레벨 */}
+            <div className="mb-3 flex gap-2">
+              <div className="h-6 w-20 rounded bg-gray-200" />
+              <div className="h-6 w-16 rounded bg-gray-200" />
+              <div className="h-4 w-16 rounded bg-gray-200" />
+            </div>
+          </div>
+
+          {/* 가격, 버튼 스켈레톤 */}
+          <div className="flex flex-shrink-0 flex-col items-end justify-between">
+            <div className="space-y-1 text-right">
+              <div className="h-7 w-24 rounded bg-gray-200" />
+              <div className="h-5 w-20 rounded bg-gray-200" />
+            </div>
+            <div className="flex items-center gap-4">
+              <div className="h-5 w-5 rounded bg-gray-200" />
+              <div className="h-10 w-24 rounded bg-gray-200" />
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  if (!data) return
+
   return (
     <div className="rounded-xl border border-gray-200 bg-white p-6 transition-shadow hover:shadow-md">
       <div className="flex gap-4">
         {/* 이미지 */}
-        <div className="flex h-auto w-40 flex-shrink-0 items-center">
-          <img
-            src={data.lecture_info.thumbnail_img_url}
-            alt={data.lecture_info.title}
-            className="max-h-24 w-full rounded-lg object-cover"
-          />
+        <div className="flex h-auto min-w-40 items-center rounded-lg">
+          {data.lecture_info.thumbnail_img_url ? (
+            <img
+              src={data.lecture_info.thumbnail_img_url}
+              alt={data.lecture_info.title}
+              className="max-h-24 w-full object-cover"
+            />
+          ) : (
+            <div className="flex h-24 w-full items-center justify-center bg-gray-200 text-gray-400">
+              Image
+            </div>
+          )}
         </div>
 
         {/* 컨텐츠 */}
@@ -199,15 +262,15 @@ function CourseBookmarkCard({
             </Badge>
             <Badge
               variant={
-                data.lecture_info.difficulty === 'BEGINNER'
-                  ? 'default'
+                data.lecture_info.difficulty === 'EASY'
+                  ? 'success'
                   : data.lecture_info.difficulty === 'NORMAL'
                     ? 'primary'
                     : 'danger'
               }
               size="sm"
             >
-              {data.lecture_info.difficulty === 'BEGINNER'
+              {data.lecture_info.difficulty === 'EASY'
                 ? '초급'
                 : data.lecture_info.difficulty === 'NORMAL'
                   ? '중급'
@@ -234,7 +297,7 @@ function CourseBookmarkCard({
           </div>
           <div className="flex items-center gap-4">
             <button
-              onClick={() => onBookmarkToggle(data.id)}
+              onClick={() => onBookmarkToggle?.(data.id)}
               className="cursor-pointer transition-transform hover:scale-110"
             >
               <Bookmark className="fill-primary-500 text-primary-500 h-5 w-5" />
@@ -250,30 +313,5 @@ function CourseBookmarkCard({
         </div>
       </div>
     </div>
-  )
-}
-
-// 메인 북마크 카드 컴포넌트 (타입별로 분기)
-export default function BookmarkCard({
-  data,
-  onBookmarkToggle,
-  onViewClick,
-}: BookmarkCardProps) {
-  if (data.type === 'job') {
-    return (
-      <JobBookmarkCard
-        data={data}
-        onBookmarkToggle={onBookmarkToggle}
-        onViewClick={onViewClick}
-      />
-    )
-  }
-
-  return (
-    <CourseBookmarkCard
-      data={data}
-      onBookmarkToggle={onBookmarkToggle}
-      onViewClick={onViewClick}
-    />
   )
 }

--- a/src/components/mypage/BookmarkCard.tsx
+++ b/src/components/mypage/BookmarkCard.tsx
@@ -66,7 +66,7 @@ export function JobBookmarkCard({
             </div>
           </div>
 
-          {/* 버튼 스켈레톤 - 실제와 동일한 구조 */}
+          {/* 버튼 스켈레톤 */}
           <div className="flex flex-shrink-0 flex-col items-start gap-2">
             <div className="flex items-center gap-4">
               <div className="h-5 w-5 rounded bg-gray-200" />

--- a/src/components/mypage/CourseContents.tsx
+++ b/src/components/mypage/CourseContents.tsx
@@ -1,121 +1,121 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Search } from 'lucide-react'
-import BookmarkCard from './BookmarkCard'
 import useDebounce from '../../hooks/useDebounce'
-import { toast } from 'sonner'
-import Toast from '../common/toast/Toast'
-
-const COURSES_DATA = [
-  {
-    type: 'course' as const,
-    id: 1,
-    lecture_info: {
-      uuid: 'uuid-001',
-      title: 'React 완벽 마스터 강의 - 기초부터 고급까지',
-      instructor: '김개발',
-      thumbnail_img_url:
-        'https://images.unsplash.com/photo-1633356122544-f134324a6cee?w=400&h=300&fit=crop',
-      platform: 'Inflearn',
-      description: 'React의 기초부터 고급 기술까지 완벽하게 마스터하는 강의',
-      difficulty: 'BEGINNER' as const, // BEGINNER, NORMAL, ADVANCED
-      duration: '12:30',
-      original_price: 89000,
-      discount_price: 59000,
-      average_rating: 4.8,
-      url_link: 'https://inflearn.com/course/react-perfect',
-    },
-    created_at: '2025-10-01T12:00:00Z',
-  },
-  {
-    type: 'course' as const,
-    id: 2,
-    lecture_info: {
-      uuid: 'uuid-002',
-      title: 'Node.js 백엔드 개발 완주 - 실무 프로젝트까지',
-      instructor: '박서버',
-      thumbnail_img_url:
-        'https://images.unsplash.com/photo-1633356122544-f134324a6cee?w=400&h=300&fit=crop',
-      platform: 'Udemy',
-      description: 'Node.js를 활용한 백엔드 개발 실무 프로젝트',
-      difficulty: 'NORMAL' as const,
-      duration: '18:45',
-      original_price: 120000,
-      discount_price: 79000,
-      average_rating: 4.5,
-      url_link: 'https://udemy.com/course/nodejs-backend',
-    },
-    created_at: '2025-10-02T14:30:00Z',
-  },
-  {
-    type: 'course' as const,
-    id: 3,
-    lecture_info: {
-      uuid: 'uuid-003',
-      title: 'Python 데이터 사이언스 마스터클래스',
-      instructor: '이데이터',
-      thumbnail_img_url:
-        'https://images.unsplash.com/photo-1633356122544-f134324a6cee?w=400&h=300&fit=crop',
-      platform: 'Inflearn',
-      description: 'Python을 활용한 데이터 분석 및 머신러닝 실무',
-      difficulty: 'ADVANCED' as const,
-      duration: '25:15',
-      original_price: 150000,
-      discount_price: 99000,
-      average_rating: 4.9,
-      url_link: 'https://inflearn.com/course/python-data-science',
-    },
-    created_at: '2025-10-03T09:15:00Z',
-  },
-  {
-    type: 'course' as const,
-    id: 4,
-    lecture_info: {
-      uuid: 'uuid-004',
-      title: 'JavaScript ES6+ 완벽 가이드 - 모던 자바스크립트',
-      instructor: '최자바',
-      thumbnail_img_url:
-        'https://images.unsplash.com/photo-1633356122544-f134324a6cee?w=400&h=300&fit=crop',
-      platform: 'Udemy',
-      description: 'ES6+의 모든 기능을 활용한 모던 JavaScript 완벽 가이드',
-      difficulty: 'BEGINNER' as const,
-      duration: '15:20',
-      original_price: 75000,
-      discount_price: 49000,
-      average_rating: 4.7,
-      url_link: 'https://udemy.com/course/javascript-es6',
-    },
-    created_at: '2025-10-04T16:45:00Z',
-  },
-]
+import { CourseBookmarkCard } from './BookmarkCard'
+import { showToast } from '../../utils/showToast'
+import type { LectureBookmark } from '../../types/apiInterface/mypageInterface'
 
 function CourseContents() {
-  const [courses, setCourses] = useState(COURSES_DATA)
+  const [courses, setCourses] = useState<LectureBookmark[]>([])
   const [searchQuery, setSearchQuery] = useState('')
   const debouncedSearchQuery = useDebounce(searchQuery)
+  const [isLoading, setIsLoading] = useState(false)
+
+  useEffect(() => {
+    const fetchCourses = async () => {
+      setIsLoading(true)
+      await new Promise((resolve) => setTimeout(resolve, 1000))
+      try {
+        // 더미 데이터
+        const mockData: LectureBookmark[] = [
+          {
+            id: 1,
+            lecture_info: {
+              uuid: 'uuid-001',
+              title: 'React 완벽 마스터 강의 - 기초부터 고급까지',
+              instructor: '김개발',
+              thumbnail_img_url: '',
+              platform: 'Inflearn',
+              description:
+                'React의 기초부터 고급 기술까지 완벽하게 마스터하는 강의',
+              difficulty: 'EASY',
+              duration: '12:30',
+              original_price: 89000,
+              discount_price: 59000,
+              average_rating: 4.8,
+              url_link: 'https://inflearn.com/course/react-perfect',
+            },
+            created_at: '2025-10-01T12:00:00Z',
+          },
+          {
+            id: 2,
+            lecture_info: {
+              uuid: 'uuid-002',
+              title: 'Node.js 백엔드 개발 완주 - 실무 프로젝트까지',
+              instructor: '박서버',
+              thumbnail_img_url:
+                'https://images.unsplash.com/photo-1633356122544-f134324a6cee?w=400&h=300&fit=crop',
+              platform: 'Udemy',
+              description: 'Node.js를 활용한 백엔드 개발 실무 프로젝트',
+              difficulty: 'NORMAL',
+              duration: '18:45',
+              original_price: 120000,
+              discount_price: 79000,
+              average_rating: 4.5,
+              url_link: 'https://udemy.com/course/nodejs-backend',
+            },
+            created_at: '2025-10-02T14:30:00Z',
+          },
+          {
+            id: 3,
+            lecture_info: {
+              uuid: 'uuid-003',
+              title: 'Python 데이터 사이언스 마스터클래스',
+              instructor: '이데이터',
+              thumbnail_img_url:
+                'https://images.unsplash.com/photo-1633356122544-f134324a6cee?w=400&h=300&fit=crop',
+              platform: 'Inflearn',
+              description: 'Python을 활용한 데이터 분석 및 머신러닝 실무',
+              difficulty: 'HARD',
+              duration: '25:15',
+              original_price: 150000,
+              discount_price: 99000,
+              average_rating: 4.9,
+              url_link: 'https://inflearn.com/course/python-data-science',
+            },
+            created_at: '2025-10-03T09:15:00Z',
+          },
+          {
+            id: 4,
+            lecture_info: {
+              uuid: 'uuid-004',
+              title: 'JavaScript ES6+ 완벽 가이드 - 모던 자바스크립트',
+              instructor: '최자바',
+              thumbnail_img_url:
+                'https://images.unsplash.com/photo-1633356122544-f134324a6cee?w=400&h=300&fit=crop',
+              platform: 'Udemy',
+              description:
+                'ES6+의 모든 기능을 활용한 모던 JavaScript 완벽 가이드',
+              difficulty: 'EASY',
+              duration: '15:20',
+              original_price: 75000,
+              discount_price: 49000,
+              average_rating: 4.7,
+              url_link: 'https://udemy.com/course/javascript-es6',
+            },
+            created_at: '2025-10-04T16:45:00Z',
+          },
+        ]
+        setCourses(mockData)
+      } catch {
+        setIsLoading(false)
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    fetchCourses()
+  }, [])
 
   const handleBookmarkToggle = (courseId: number) => {
     setCourses((prevCourses) =>
       prevCourses.filter((course) => course.id !== courseId)
     )
-    toast.custom((t) => (
-      <Toast
-        id={t}
-        title="북마크 삭제"
-        message="북마크가 삭제되었습니다"
-        type="success"
-      />
-    ))
+    showToast('북마크가 삭제되었습니다', 'success', '북마크 삭제')
   }
 
   const handleViewClick = (courseId: number) => {
-    toast.custom((t) => (
-      <Toast
-        id={t}
-        title="강의보기 클릭"
-        message={`강의 id: ${courseId}`}
-        type="success"
-      />
-    ))
+    showToast(`강의 id : ${courseId}`, 'success', '강의보기 클릭')
   }
 
   const filterCourses = courses.filter(
@@ -158,7 +158,11 @@ function CourseContents() {
 
         {/* 북마크 리스트 */}
         <div className="space-y-4">
-          {filterCourses.length === 0 ? (
+          {isLoading ? (
+            [...Array(3)].map((_, index) => (
+              <CourseBookmarkCard key={index} isLoading />
+            ))
+          ) : filterCourses.length === 0 ? (
             <div className="py-12 text-center text-gray-500">
               {searchQuery
                 ? '검색 결과가 없습니다'
@@ -166,7 +170,7 @@ function CourseContents() {
             </div>
           ) : (
             filterCourses.map((course) => (
-              <BookmarkCard
+              <CourseBookmarkCard
                 key={course.id}
                 data={course}
                 onBookmarkToggle={handleBookmarkToggle}

--- a/src/components/mypage/JobsContents.tsx
+++ b/src/components/mypage/JobsContents.tsx
@@ -1,105 +1,104 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Search } from 'lucide-react'
-import BookmarkCard from './BookmarkCard'
 import useDebounce from '../../hooks/useDebounce'
-import { toast } from 'sonner'
-import Toast from '../common/toast/Toast'
 import { birthdayFormat } from '../../utils/dateFormat'
-
-const JOBS_DATA = [
-  {
-    type: 'job' as const,
-    id: 101,
-    uuid: 'uuid-0001',
-    title: 'Vue.js 프론트엔드 개발팀 모집',
-    introduction: 'Vue.js로 프로젝트를 함께 진행할 팀원을 모집합니다.',
-    thumbnail:
-      'https://images.unsplash.com/photo-1633356122544-f134324a6cee?w=400&h=300&fit=crop',
-    max_headcount: 4,
-    start_at: '2025-11-01T10:00:00Z',
-    end_at: birthdayFormat('2025-12-15T18:00:00Z'),
-    status: 'PENDING' as const,
-    courses: [
-      { name: 'Vue.js 완벽 가이드', instructor: '정복' },
-      { name: 'Nuxt.js 실전', instructor: '김패스트' },
-    ],
-    tags: ['Vue.js', '프론트엔드', '팀프로젝트'],
-    views: 245,
-    bookmark_count: 38,
-    bookmarked_at: '2025-10-16T14:00:00Z',
-  },
-  {
-    type: 'job' as const,
-    id: 102,
-    uuid: 'uuid-0002',
-    title: '딥러닝 AI 프로젝트 스터디팀 모집',
-    introduction:
-      '딥러닝과 AI 기술을 함께 학습하고 프로젝트를 진행할 스터디원을 모집합니다.',
-    thumbnail:
-      'https://images.unsplash.com/photo-1633356122544-f134324a6cee?w=400&h=300&fit=crop',
-    max_headcount: 3,
-    start_at: '2025-11-10T10:00:00Z',
-    end_at: birthdayFormat('2025-12-12T18:00:00Z'),
-    status: 'ACTIVE' as const,
-    courses: [
-      { name: '딥러닝 완벽 마스터', instructor: '김딥러닝' },
-      { name: 'TensorFlow 실전', instructor: '박텐서플로' },
-    ],
-    tags: ['딥러닝', 'AI', '머신러닝'],
-    views: 289,
-    bookmark_count: 62,
-    bookmarked_at: '2025-10-17T09:30:00Z',
-  },
-  {
-    type: 'job' as const,
-    id: 103,
-    uuid: 'uuid-0003',
-    title: 'Unity 게임 개발 프로젝트팀 멤버 모집',
-    introduction: 'Unity를 활용한 3D 게임 개발 프로젝트 팀원을 모집합니다.',
-    thumbnail:
-      'https://images.unsplash.com/photo-1633356122544-f134324a6cee?w=400&h=300&fit=crop',
-    max_headcount: 6,
-    start_at: '2025-11-15T10:00:00Z',
-    end_at: birthdayFormat('2026-02-28T18:00:00Z'),
-    status: 'PENDING' as const,
-    courses: [
-      { name: 'Unity 게임 개발 마스터', instructor: '박유니티' },
-      { name: 'C# 게임 프로그래밍', instructor: '김씨샵' },
-    ],
-    tags: ['Unity', 'C#', '게임개발', '3D개발'],
-    views: 412,
-    bookmark_count: 105,
-    bookmarked_at: '2025-10-18T11:20:00Z',
-  },
-]
+import { JobBookmarkCard } from './BookmarkCard'
+import { showToast } from '../../utils/showToast'
+import type { StudyJobs } from '../../types/apiInterface/mypageInterface'
 
 function JobsContents() {
-  const [jobs, setJobs] = useState(JOBS_DATA)
-
+  const [jobs, setJobs] = useState<StudyJobs[]>([])
   const [searchQuery, setSearchQuery] = useState('')
   const debouncedSearchQuery = useDebounce(searchQuery)
+  const [isLoading, setIsLoading] = useState(false)
+
+  useEffect(() => {
+    const fetchJobs = async () => {
+      setIsLoading(true)
+      await new Promise((resolve) => setTimeout(resolve, 1000))
+      try {
+        // 더미 데이터
+        const mockData: StudyJobs[] = [
+          {
+            id: 101,
+            uuid: 'uuid-0001',
+            title: 'Vue.js 프론트엔드 개발팀 모집',
+            introduction: 'Vue.js로 프로젝트를 함께 진행할 팀원을 모집합니다.',
+            thumbnail: '',
+            max_headcount: 4,
+            start_at: '2025-11-01T10:00:00Z',
+            end_at: birthdayFormat('2025-12-15T18:00:00Z'),
+            status: 'PENDING',
+            courses: [
+              { name: 'Vue.js 완벽 가이드', instructor: '정복' },
+              { name: 'Nuxt.js 실전', instructor: '김패스트' },
+            ],
+            tags: ['Vue.js', '프론트엔드', '팀프로젝트'],
+            views: 245,
+            bookmark_count: 38,
+            bookmarked_at: '2025-10-16T14:00:00Z',
+          },
+          {
+            id: 102,
+            uuid: 'uuid-0002',
+            title: '딥러닝 AI 프로젝트 스터디팀 모집',
+            introduction:
+              '딥러닝과 AI 기술을 함께 학습하고 프로젝트를 진행할 스터디원을 모집합니다.',
+            thumbnail:
+              'https://images.unsplash.com/photo-1633356122544-f134324a6cee?w=400&h=300&fit=crop',
+            max_headcount: 3,
+            start_at: '2025-11-10T10:00:00Z',
+            end_at: birthdayFormat('2025-12-12T18:00:00Z'),
+            status: 'ONGOING',
+            courses: [
+              { name: '딥러닝 완벽 마스터', instructor: '김딥러닝' },
+              { name: 'TensorFlow 실전', instructor: '박텐서플로' },
+            ],
+            tags: ['딥러닝', 'AI', '머신러닝'],
+            views: 289,
+            bookmark_count: 62,
+            bookmarked_at: '2025-10-17T09:30:00Z',
+          },
+          {
+            id: 103,
+            uuid: 'uuid-0003',
+            title: 'Unity 게임 개발 프로젝트팀 멤버 모집',
+            introduction:
+              'Unity를 활용한 3D 게임 개발 프로젝트 팀원을 모집합니다.',
+            thumbnail:
+              'https://images.unsplash.com/photo-1633356122544-f134324a6cee?w=400&h=300&fit=crop',
+            max_headcount: 6,
+            start_at: '2025-11-15T10:00:00Z',
+            end_at: birthdayFormat('2026-02-28T18:00:00Z'),
+            status: 'PENDING',
+            courses: [
+              { name: 'Unity 게임 개발 마스터', instructor: '박유니티' },
+              { name: 'C# 게임 프로그래밍', instructor: '김씨샵' },
+            ],
+            tags: ['Unity', 'C#', '게임개발', '3D개발'],
+            views: 412,
+            bookmark_count: 105,
+            bookmarked_at: '2025-10-18T11:20:00Z',
+          },
+        ]
+        setJobs(mockData)
+      } catch {
+        setIsLoading(false)
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    fetchJobs()
+  }, [])
 
   const handleBookmarkToggle = (jobId: number) => {
     setJobs((prevJobs) => prevJobs.filter((job) => job.id !== jobId))
-    toast.custom((t) => (
-      <Toast
-        id={t}
-        title="북마크 삭제"
-        message="북마크가 삭제되었습니다"
-        type="success"
-      />
-    ))
+    showToast('북마크가 삭제되었습니다', 'success', '북바크 삭제')
   }
 
   const handleViewClick = (jobId: number) => {
-    toast.custom((t) => (
-      <Toast
-        id={t}
-        title="공고보기 클릭"
-        message={`공고 id: ${jobId}`}
-        type="success"
-      />
-    ))
+    showToast(`공고 id : ${jobId}`, 'success', '공고보기 클릭')
   }
 
   const filterJobs = jobs.filter((job) =>
@@ -136,7 +135,11 @@ function JobsContents() {
 
         {/* 북마크 리스트 */}
         <div className="space-y-4">
-          {filterJobs.length === 0 ? (
+          {isLoading ? (
+            [...Array(3)].map((_, index) => (
+              <JobBookmarkCard key={index} isLoading />
+            ))
+          ) : filterJobs.length === 0 ? (
             <div className="py-12 text-center text-gray-500">
               {searchQuery
                 ? '검색 결과가 없습니다'
@@ -144,7 +147,7 @@ function JobsContents() {
             </div>
           ) : (
             filterJobs.map((job) => (
-              <BookmarkCard
+              <JobBookmarkCard
                 key={job.id}
                 data={job}
                 onBookmarkToggle={handleBookmarkToggle}


### PR DESCRIPTION
## PR 제목

<!-- 예: [Feat] 로그인 UI 구현 -->
- [Refactor] 북마크 공고/강의 리펙토링 및 로딩 스켈레톤으로 변경
## 관련 이슈

<!-- 예: closes #123 -->
- closes #112 
## 변경 사항 요약

<!-- 변경된 내용을 간단히 작성해주세요 -->
- 북마크 공고/강의 리펙토링
- 더미데이터로 임시로 실제 api 호출처럼 구현
- types의 api 인터페이스로 변경
- bookmark 카드 컴포넌트에 loading props로 조건부 랜더링 (스켈레톤 or 실제 랜더링)
## 체크리스트

- [ ] 코드가 빌드되고 실행되는지 확인 (로컬에서)
- [ ] 관련 파일 및 문서 수정 여부 확인
- [ ] 리뷰 요청 내용 작성
- [ ] 코드에 불필요한 console.log & console.error 제거
- [ ] PR 제목이 규칙에 맞게 작성됨 (예: [Fix]/[Feat]/[Docs])

## 스크린샷 (선택)

<!-- 스샷 보여주고 싶으면 첨부 -->
<img width="1313" height="720" alt="image" src="https://github.com/user-attachments/assets/2aa9521f-597a-4802-992f-0d5aa5f71f2d" />

## 리뷰어

- @devjaesung
- @chen4023
