### PR TITLE
[Hotfix] 리프레시, 내정보API 무한 호출 버그 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,13 +30,11 @@ function App() {
         const res = await api.post<{
           detail: string
           data: {
-            access_token: string
-            token_type: string
-            expires_in: number
+            access: string
           }
         }>('/v1/auth/refresh', {}, { skipAuth: true })
 
-        setAccessToken(res.data.access_token) // data 객체 안의 access_token 사용
+        setAccessToken(res.data.access) // data 객체 안의 access 사용
 
         // accessToken으로 user 정보 조회
         const userRes = await api.get<{

--- a/src/api/interceptors.tsx
+++ b/src/api/interceptors.tsx
@@ -95,7 +95,12 @@ export const setupInterceptors = (apiClient: AxiosInstance) => {
 
         try {
           // refreshToken으로 새로운 accessToken 발급
-          const response = await api.post<{ access_token: string }>(
+          const response = await api.post<{
+            detail: string
+            data: {
+              access: string
+            }
+          }>(
             `${import.meta.env.VITE_API_BASE_URL}/v1/auth/refresh`,
             {},
             {
@@ -104,7 +109,7 @@ export const setupInterceptors = (apiClient: AxiosInstance) => {
             }
           )
 
-          const newAccessToken = response.access_token
+          const newAccessToken = response.data.access
           useToken.getState().setAccessToken(newAccessToken)
 
           // 원래 요청에 새 토큰 추가 후 재시도


### PR DESCRIPTION
## PR 제목

<!-- 예: [Feat] 로그인 UI 구현 -->
- [Hotfix] 리프레시, 내정보API 무한 호출 버그 수정
## 관련 이슈

<!-- 예: closes #123 -->
- closes #120 
## 변경 사항 요약

<!-- 변경된 내용을 간단히 작성해주세요 -->
- API 명세서와 다른 데이터가 와서 access token을 제대로 저장을 못해서 API 호출이 무한으로 일어나는 오류 수정
## 체크리스트

- [ ] 코드가 빌드되고 실행되는지 확인 (로컬에서)
- [ ] 관련 파일 및 문서 수정 여부 확인
- [ ] 리뷰 요청 내용 작성
- [ ] 코드에 불필요한 console.log & console.error 제거
- [ ] PR 제목이 규칙에 맞게 작성됨 (예: [Fix]/[Feat]/[Docs])

## 스크린샷 (선택)

<!-- 스샷 보여주고 싶으면 첨부 -->

## 리뷰어

- @devjaesung
- @chen4023
