### PR TITLE
[Feat] 헤더 로그인 인증 연동 및 조건부 렌더링 반영

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,15 +15,31 @@ import { useToken } from './store/useTokenStore'
 import { useUserStore } from './store/useUserStore'
 import { api } from './api/client'
 import ApiTestPage from './tests/ApiTestPage'
+import { useGetUserMe } from './api/services/mypage/profile'
 
 function App() {
-  const [isCheck, setIsCheck] = useState(true)
-  const { accessToken, setAccessToken } = useToken()
-  const { user, setUser, clearUser } = useUserStore()
+  const [isCheck, setIsCheck] = useState(true) //ture는 인증 확인중 / false는 인증 확인 완료
+
+  const accessToken = useToken((state) => state.accessToken)
+  const setAccessToken = useToken((state) => state.setAccessToken)
+
+  const user = useUserStore((state) => state.user)
+  const setUser = useUserStore((state) => state.setUser)
+  const clearUser = useUserStore((state) => state.clearUser)
+
+  const {
+    data: meData,
+    isLoading,
+    error,
+  } = useGetUserMe(!!accessToken && !user) // !!accessToken = accessToken이 있으면 true / !user = user가 없으면 true
 
   useEffect(() => {
     const initAuth = async () => {
-      if (accessToken && user) return // 이미 메모리에 토큰이 있으면 재요청x
+      //accessToken과 user가 모두 있으면 종료
+      if (accessToken && user) {
+        setIsCheck(false)
+        return
+      }
 
       try {
         // refreshToken으로 accessToken 발급
@@ -34,24 +50,22 @@ function App() {
           }
         }>('/v1/auth/refresh', {}, { skipAuth: true })
 
-        setAccessToken(res.data.access) // data 객체 안의 access 사용
+        const newAccessToken = res.data.access
+        setAccessToken(newAccessToken)
 
-        // accessToken으로 user 정보 조회
+        // user 정보 조회
         const userRes = await api.get<{
-          detail: string
-          data: {
-            id: number
-            email: string
-            nickname: string
-            name: string
-            phone_number: string
-            birthday: string
-            profile_image_url: string
-            created_at: string
-          }
+          id: number
+          email: string
+          nickname: string
+          name: string
+          phone_number: string
+          birthday: string
+          profile_img_url: string | null
+          created_at: string
         }>('/v1/users/me')
 
-        setUser(userRes.data)
+        setUser(userRes)
       } catch {
         clearUser() // refreshToken이 없거나 만료 > 로그아웃 상태
       } finally {
@@ -62,6 +76,22 @@ function App() {
     initAuth()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
+
+  //탠스텍쿼리로 조회한 user 정보 저장
+  useEffect(() => {
+    if (meData) {
+      setUser(meData)
+      setIsCheck(false)
+    }
+  }, [meData, setUser])
+
+  // 에러 발생하면 로그아웃 처리
+  useEffect(() => {
+    if (error) {
+      clearUser()
+      setIsCheck(false)
+    }
+  }, [error, clearUser])
 
   const routes = useRoutes([
     {
@@ -81,7 +111,7 @@ function App() {
     { path: '*', element: <NotFoundPage /> },
   ])
 
-  if (isCheck) return
+  if (isCheck || isLoading) return
 
   return (
     <>

--- a/src/api/services/mypage/profile.ts
+++ b/src/api/services/mypage/profile.ts
@@ -1,0 +1,12 @@
+import { api } from '../../client'
+import { useSimpleQuery } from '../../Helper/useSimpleQuery'
+import type { MeResponse } from '../../../types/apiInterface/mypageInterface'
+
+// 내 정보 조회 (GET)
+export const useGetUserMe = (enabled = true) => {
+  return useSimpleQuery<MeResponse>(
+    ['/v1/users/me'],
+    () => api.get<MeResponse>('/v1/users/me'),
+    { enabled } // 필요할 때만 실행
+  )
+}

--- a/src/components/common/Avatar.tsx
+++ b/src/components/common/Avatar.tsx
@@ -5,7 +5,7 @@ type AvatarSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl'
 
 interface AvatarProps extends HTMLAttributes<HTMLDivElement> {
   name: string
-  imgUrl?: string
+  imgUrl?: string | null
   size?: AvatarSize
   isHeader?: boolean
 }

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -7,30 +7,33 @@ import Avatar from '../common/Avatar'
 import { useLogout } from '../../api/services/Auth'
 import { showToast } from '../../utils/showToast'
 import { useToken } from '../../store/useTokenStore'
+import { useUserStore } from '../../store/useUserStore'
 
 function Header() {
-  const isLogin = true // false일땐 비로그인
   const navigate = useNavigate()
   const [sidebarOpen, setSidebarOpen] = useState(false)
 
   const { mutate: LogoutMutate } = useLogout()
   const { clearAccessToken } = useToken()
 
+  const user = useUserStore((state) => state.user)
+  const clearUser = useUserStore((state) => state.clearUser)
+
+  const isLogin = !!user
+
   const logout = () => {
     LogoutMutate(undefined, {
       onSuccess: (data) => {
         clearAccessToken()
+        clearUser()
         showToast(`${data.detail}`, 'success', '로그아웃')
-        navigate('/login')
+        navigate('/')
       },
       onError: (error) => {
         showToast(`${error.response?.data.error}`, 'error', '로그아웃')
       },
     })
   }
-
-  const userName = '김개발'
-  const userEmail = 'kim.dev@example.com'
 
   const navLinks = [
     { label: '강의 목록', path: '/ddd', icon: Book },
@@ -182,38 +185,37 @@ function Header() {
               </nav>
             </div>
 
-            {/* 유저 정보 + 로그아웃 */}
-            <div className="border-t border-gray-200">
-              {/* 유저 정보 */}
-              <div
-                className="hover:bg-primary-50 flex cursor-pointer items-center gap-3 px-4 py-4"
-                onClick={() => {
-                  navigate('/mypage')
-                  setSidebarOpen(false)
-                }}
-              >
-                <Avatar name={userName} size="md" />
-                <div className="flex flex-1 flex-col">
-                  <p className="text-sm font-semibold text-gray-900">
-                    {userName}
-                  </p>
-                  <p className="text-xs text-gray-500">{userEmail}</p>
+            {/* 로그인 상태일 때만 유저 정보 + 로그아웃 표시 */}
+            {isLogin && user && (
+              <div className="border-t border-gray-200">
+                <div
+                  className="hover:bg-primary-50 flex cursor-pointer items-center gap-3 px-4 py-4"
+                  onClick={() => {
+                    navigate('/mypage')
+                    setSidebarOpen(false)
+                  }}
+                >
+                  <Avatar name={user.name ?? user.nickname} size="md" />
+                  <div className="flex flex-1 flex-col">
+                    <p className="text-sm font-semibold text-gray-900">
+                      {user.name ?? user.nickname}
+                    </p>
+                    <p className="text-xs text-gray-500">{user.email}</p>
+                  </div>
                 </div>
-              </div>
 
-              {/* 로그아웃 버튼 */}
-              <button
-                onClick={() => {
-                  // 로그아웃 로직
-                  logout()
-                  setSidebarOpen(false)
-                }}
-                className="hover:text-danger-500 mb-5 flex min-w-58 cursor-pointer items-center justify-center gap-3 border-t border-gray-100 bg-gray-100 px-4 py-2 text-sm text-gray-700 transition hover:bg-red-50"
-              >
-                <LogOut size={16} className="rotate-180 transform" />
-                <span>로그아웃</span>
-              </button>
-            </div>
+                <button
+                  onClick={() => {
+                    logout()
+                    setSidebarOpen(false)
+                  }}
+                  className="hover:text-danger-500 mb-5 flex min-w-58 cursor-pointer items-center justify-center gap-3 border-t border-gray-100 bg-gray-100 px-4 py-2 text-sm text-gray-700 transition hover:bg-red-50"
+                >
+                  <LogOut size={16} className="rotate-180 transform" />
+                  <span>로그아웃</span>
+                </button>
+              </div>
+            )}
           </div>
         </>
       )}

--- a/src/components/layout/HeaderIsLogin.tsx
+++ b/src/components/layout/HeaderIsLogin.tsx
@@ -3,18 +3,26 @@ import Avatar from '../common/Avatar'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import UserDropdown from '../common/UserDropdown'
 import { useNavigate } from 'react-router'
+import { useUserStore } from '../../store/useUserStore'
+import { useToken } from '../../store/useTokenStore'
+import { useLogout } from '../../api/services/Auth'
+import { showToast } from '../../utils/showToast'
 
 interface HeaderIsLoginProps {
   isMobile?: boolean
 }
 
 function HeaderIsLogin({ isMobile = false }: HeaderIsLoginProps) {
-  const userName = '김개발'
-  const notificationCount = '3'
   const [open, setOpen] = useState(false)
-
   const dropdownRef = useRef<HTMLDivElement>(null)
   const navigate = useNavigate()
+
+  const user = useUserStore((state) => state.user)
+  const clearUser = useUserStore((state) => state.clearUser)
+  const { clearAccessToken } = useToken()
+  const { mutate: LogoutMutate } = useLogout()
+
+  const notificationCount = '3' // 알림 하드코딩 되어있는거 나중에 수정해야 함
 
   const handleClickOutside = useCallback((event: MouseEvent) => {
     if (
@@ -39,13 +47,27 @@ function HeaderIsLogin({ isMobile = false }: HeaderIsLoginProps) {
   }
 
   const handleLogoutClick = () => {
-    setOpen(false)
+    LogoutMutate(undefined, {
+      onSuccess: (data) => {
+        clearAccessToken()
+        clearUser()
+        showToast(`${data.detail}`, 'success', '로그아웃')
+        setOpen(false)
+        navigate('/login')
+      },
+      onError: (error) => {
+        showToast(`${error.response?.data.error}`, 'error', '로그아웃')
+        setOpen(false)
+      },
+    })
   }
 
   const handleUserInfoClick = () => {
-    if (isMobile) return // 모바일이면 종료
+    if (isMobile) return
     setOpen((prev) => !prev)
   }
+
+  if (!user) return null // user가 없으면 null(아무것도 렌더링 안함)
 
   return (
     <div className="relative ml-8 flex items-center" ref={dropdownRef}>
@@ -64,9 +86,9 @@ function HeaderIsLogin({ isMobile = false }: HeaderIsLoginProps) {
         }`}
         onClick={handleUserInfoClick}
       >
-        <Avatar name={userName} size="sm" isHeader />
+        <Avatar name={user.name ?? user.nickname} size="sm" isHeader />
         <span className="text-primary-600 text-base font-medium">
-          {userName}
+          {user.name ?? user.nickname}
         </span>
       </div>
 

--- a/src/components/mypage/ProfileContents.tsx
+++ b/src/components/mypage/ProfileContents.tsx
@@ -6,26 +6,26 @@ import { PROFILE_FIELDS } from '../../constants/myPageProfile'
 import PasswordChangeModal from './PasswordChangeModal'
 import UserLeaveModal from './UserLeaveModal'
 import { birthdayFormat } from '../../utils/dateFormat'
-import type { UserProfileData } from '../../types/userType'
 import { phoneFormat } from '../../utils/phoneFormat'
+import type { MeResponse } from '../../types/apiInterface/mypageInterface'
 
 function ProfileContents() {
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [isPasswordModalOpen, setIsPasswordModalOpen] = useState(false)
   const [isWithdrawalModalOpen, setIsWithdrawalModalOpen] = useState(false)
-  const [formData, setFormData] = useState<UserProfileData>({
+  const [formData, setFormData] = useState<MeResponse>({
     id: 1,
     email: 'kim.dev@example.com',
     nickname: 'ozdev',
     name: '김개발',
     phone_number: phoneFormat('01012345678'),
     birthday: birthdayFormat('1998-01-23'),
-    profile_image_url:
+    profile_img_url:
       'https://images.unsplash.com/photo-1633356122544-f134324a6cee?w=400&h=300&fit=crop',
     created_at: '2025-01-01T10:00:00Z',
   })
 
-  const handleSave = (newData: UserProfileData) => {
+  const handleSave = (newData: MeResponse) => {
     setFormData(newData)
     setIsModalOpen(false)
   }
@@ -61,7 +61,7 @@ function ProfileContents() {
           <Avatar
             name={formData.name}
             size="2xl"
-            imgUrl={formData.profile_image_url}
+            imgUrl={formData.profile_img_url}
           />
           <p className="text-center text-lg font-semibold text-gray-900">
             프로필 이미지
@@ -78,7 +78,7 @@ function ProfileContents() {
                 {field.label}
               </label>
               <div className="rounded-md bg-gray-50 px-4 py-2.5 text-gray-900">
-                {formData[field.key as keyof UserProfileData]}
+                {formData[field.key as keyof MeResponse]}
               </div>
             </div>
           ))}

--- a/src/components/mypage/ProfileEditModal.tsx
+++ b/src/components/mypage/ProfileEditModal.tsx
@@ -4,14 +4,14 @@ import Button from '../common/Button'
 import InputWithLabel from '../common/InputWithLabel'
 import Modal from '../common/Modal'
 import { phoneFormat } from '../../utils/phoneFormat'
-import type { UserProfileData } from '../../types/userType'
 import { showToast } from '../../utils/showToast'
+import type { MeResponse } from '../../types/apiInterface/mypageInterface'
 
 interface ProfileEditModalProps {
   isOpen: boolean
-  profileData: UserProfileData
+  profileData: MeResponse
   onClose: () => void
-  onSave: (data: UserProfileData) => void
+  onSave: (data: MeResponse) => void
 }
 
 function ProfileEditModal({
@@ -20,7 +20,7 @@ function ProfileEditModal({
   onClose,
   onSave,
 }: ProfileEditModalProps) {
-  const [tempData, setTempData] = useState<UserProfileData>(profileData) //모달에서 수정 중인 프로필 데이터
+  const [tempData, setTempData] = useState<MeResponse>(profileData) //모달에서 수정 중인 프로필 데이터
   const [showVerificationInput, setShowVerificationInput] = useState(false) // 휴대폰 인증번호 입력창 표시 여부
   const [verificationCode, setVerificationCode] = useState('') // 인증번호
   const [isVerified, setIsVerified] = useState(false) //인증번호 확인 완료 여부
@@ -85,7 +85,7 @@ function ProfileEditModal({
     // 나중에 api 연결할떄 여기서 S3 presigned URL 받아서 업로드
     // 현재는 미리보기 이미지를 그대로 사용 (로컬 blob URL)
     if (previewImage) {
-      tempData.profile_image_url = previewImage
+      tempData.profile_img_url = previewImage
     }
 
     onSave(tempData)
@@ -129,7 +129,7 @@ function ProfileEditModal({
   const isSaveDisabled = showVerificationInput && !isVerified
 
   // 표시할 이미지: 미리보기 > 기존 프로필 이미지
-  const displayImage = previewImage || tempData.profile_image_url
+  const displayImage = previewImage || tempData.profile_img_url
 
   return (
     <Modal

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,15 +1,15 @@
 import { useState, useEffect } from 'react'
 
-export default function useDebounce<T>(value: T): T {
+export default function useDebounce<T>(value: T, delay: number = 300): T {
   const [debouncedValue, setDebouncedValue] = useState<T>(value)
 
   useEffect(() => {
     const timeout = setTimeout(() => {
       setDebouncedValue(value)
-    }, 300)
+    }, delay)
 
     return () => clearTimeout(timeout)
-  }, [value])
+  }, [value, delay])
 
   return debouncedValue
 }

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -97,7 +97,7 @@ let mockUser: UserType = {
   id: 1,
   email: 'test@test.com',
   nickname: '김개발',
-  profile_image_url: 'https://oz.com/image/ozdev.png',
+  profile_img_url: 'https://oz.com/image/ozdev.png',
   phone_number: '01012345678',
 }
 
@@ -239,7 +239,6 @@ export const handlers: HttpHandler[] = [
   ),
 
   http.get(`${url}/v1/lectures`, () => {
-    console.log('인기 강의 mock API 호출')
     return HttpResponse.json<GetPopularCoursesResponse>(mockPopularCourses)
   }),
 

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -8,6 +8,9 @@ import useDebounce from '../hooks/useDebounce'
 import { useLogin } from '../api/services/Auth'
 import { useToken } from '../store/useTokenStore'
 import { showToast } from '../utils/showToast'
+import { useUserStore } from '../store/useUserStore'
+import { api } from '../api/client'
+import type { MeResponse } from '../types/apiInterface/mypageInterface'
 
 interface Form {
   email: string
@@ -25,10 +28,10 @@ function LoginPage() {
   const [error, setError] = useState<Record<string, string>>({})
 
   const { setAccessToken } = useToken()
-
+  const { setUser } = useUserStore()
   const { mutate: LoginMutate } = useLogin()
 
-  const debounceForm = useDebounce(form)
+  const debounceForm = useDebounce(form, 500)
   useEffect(() => {
     const validator = validateAll(debounceForm)
     setError((prev) => ({ ...prev, ...validator }))
@@ -55,15 +58,30 @@ function LoginPage() {
     LoginMutate(
       { email: form.email, password: form.password },
       {
-        onSuccess: (data) => {
-          setAccessToken(data.data.access)
-          showToast('로그인 성공 했습니다', 'success', '로그인')
-          setForm(FORM_STATE)
-          setError({})
-          navigate('/')
+        onSuccess: async (data) => {
+          try {
+            const accessToken = data.data.access
+            setAccessToken(accessToken)
+
+            // user 정보 가져오기
+            const userRes = await api.get<MeResponse>('/v1/users/me')
+
+            setUser(userRes)
+
+            showToast('로그인 성공 했습니다', 'success', '로그인')
+            setForm(FORM_STATE)
+            setError({})
+            navigate('/')
+          } catch {
+            showToast(
+              '사용자 정보를 불러오는데 실패했습니다',
+              'error',
+              '로그인'
+            )
+          }
         },
-        onError: (error) => {
-          showToast(`${error.response?.data.error}`, 'error', '로그인')
+        onError: (e) => {
+          showToast(`${e.response?.data.error}`, 'error', '로그인')
         },
       }
     )

--- a/src/store/useUserStore.ts
+++ b/src/store/useUserStore.ts
@@ -10,7 +10,7 @@ export interface UserType {
   name?: string
   phone_number?: string
   birthday?: string
-  profile_image_url?: string
+  profile_img_url?: string | null
   created_at?: string
 }
 
@@ -22,12 +22,7 @@ interface UserStoreType {
 }
 
 export const useUserStore = create<UserStoreType>((set) => ({
-  // user: null,
-  user: {
-    id: 1001,
-    email: 'user@example.com',
-    nickname: '김개발',
-  },
+  user: null,
 
   setUser: (user) => set({ user }),
   getUser: async () => {

--- a/src/types/apiInterface/mypageInterface.ts
+++ b/src/types/apiInterface/mypageInterface.ts
@@ -1,16 +1,13 @@
 // 내 정보 조회 - - - - - - - - - - - -
 export interface MeResponse {
-  detail: string
-  data: {
-    id: number
-    email: string
-    nickname: string
-    name: string
-    phone_number: string
-    birthday: string
-    profile_image_url: string
-    created_at: string
-  }
+  id: number
+  email: string
+  nickname: string
+  name: string
+  phone_number: string
+  birthday: string
+  profile_img_url: string | null
+  created_at: string
 }
 
 // 내 정보 수정 - - - - - - - - - - - -


### PR DESCRIPTION
## PR 제목

<!-- 예: [Feat] 로그인 UI 구현 -->
- [Feat] 헤더 로그인 인증 연동 및 조건부 렌더링 반영
## 관련 이슈

<!-- 예: closes #123 -->
- closes #123 
## 변경 사항 요약

<!-- 변경된 내용을 간단히 작성해주세요 -->
- getUserMe 탠스텍쿼리 추가
- 로그인 연동 및 로그인상태 유지 로직 추가
- API response 타입 안맞는 거 수정
- 헤더, 로그인 페이지 수정
- 디바운스 delay 매개변수 추가
## 체크리스트

- [x] 코드가 빌드되고 실행되는지 확인 (로컬에서)
- [x] 관련 파일 및 문서 수정 여부 확인
- [x] 리뷰 요청 내용 작성
- [x] 코드에 불필요한 console.log & console.error 제거
- [x] PR 제목이 규칙에 맞게 작성됨 (예: [Fix]/[Feat]/[Docs])

## 스크린샷 (선택)

<!-- 스샷 보여주고 싶으면 첨부 -->

## 리뷰어

- @devjaesung
- @chen4023
