### PR TITLE
[Feat] 마이페이지 > 내 정보 수정 API 추가(프로필사진 변경은 s3 api 나오고 추가)

### DIFF
--- a/src/api/interceptors.tsx
+++ b/src/api/interceptors.tsx
@@ -6,7 +6,6 @@ import {
 import { toast } from 'sonner'
 import Toast from '../components/common/toast/Toast'
 import {
-  ERROR_MESSAGES,
   NETWORK_ERROR_MESSAGES,
   type ErrorResponse,
   type ErrorInfo,
@@ -31,27 +30,8 @@ const showErrorToast = (title: string, message: string) => {
 
 // 에러핸들러
 const handleError = (error: AxiosError<ErrorResponse>) => {
-  // 서버 응답이 있는 경우
-  if (error.response) {
-    const status = error.response.status
-    const serverMessage = error.response.data?.message
-
-    const errorInfo: ErrorInfo = ERROR_MESSAGES[status] ?? {
-      title: '요청 오류',
-      message: '요청 처리 중 오류가 발생했습니다',
-    }
-
-    const finalMessage = serverMessage ?? errorInfo.message
-    showErrorToast(errorInfo.title, finalMessage)
-
-    if (status === 401) {
-      useToken.getState().clearAccessToken()
-      window.location.href = '/login' // 401 에러 로그인 페이지로 이동
-    }
-  }
-
   // 요청은 만들어졌지만 응답이 없는 경우 (네트워크 에러, 타임아웃)
-  else if (error.request) {
+  if (error.request) {
     const errorCode = error.code ?? 'ERR_NETWORK'
     const errorInfo: ErrorInfo = NETWORK_ERROR_MESSAGES[errorCode] ?? {
       title: '네트워크 오류',
@@ -61,7 +41,7 @@ const handleError = (error: AxiosError<ErrorResponse>) => {
     showErrorToast(errorInfo.title, errorInfo.message)
   }
 
-  return Promise.reject(error)
+  return Promise.reject(error) // 4xx랑 5xx는 컴포넌트에서 처리하도록 그냥 전달
 }
 
 // 인터셉터 설정

--- a/src/api/services/mypage/profile.ts
+++ b/src/api/services/mypage/profile.ts
@@ -1,6 +1,16 @@
 import { api } from '../../client'
 import { useSimpleQuery } from '../../Helper/useSimpleQuery'
-import type { MeResponse } from '../../../types/apiInterface/mypageInterface'
+import type {
+  MeResponse,
+  PhoneVerificationSendRequest,
+  PhoneVerificationSendResponse,
+  PhoneVerificationConfirmRequest,
+  PhoneVerificationConfirmResponse,
+  UpdateMeRequest,
+  UpdateProfileResponse,
+} from '../../../types/apiInterface/mypageInterface'
+import { useSimpleMutation } from '../../Helper/useSimpleMutation'
+import { useUserStore } from '../../../store/useUserStore'
 
 // 내 정보 조회 (GET)
 export const useGetUserMe = (enabled = true) => {
@@ -8,5 +18,62 @@ export const useGetUserMe = (enabled = true) => {
     ['/v1/users/me'],
     () => api.get<MeResponse>('/v1/users/me'),
     { enabled } // 필요할 때만 실행
+  )
+}
+
+// 휴대폰 변경 인증코드 전송 (POST)
+export const useSendPhoneVerificationCode = () => {
+  return useSimpleMutation<
+    PhoneVerificationSendResponse['data'],
+    Error,
+    PhoneVerificationSendRequest
+  >(async (data: PhoneVerificationSendRequest) => {
+    const res = await api.post<PhoneVerificationSendResponse>(
+      '/v1/phone-verifications/phone-change/send-code',
+      data
+    )
+    return res.data
+  })
+}
+
+// 휴대폰 변경 인증코드 확인 (POST)
+export const useConfirmPhoneVerificationCode = () => {
+  return useSimpleMutation<
+    PhoneVerificationConfirmResponse['data'],
+    Error,
+    PhoneVerificationConfirmRequest
+  >(async (data: PhoneVerificationConfirmRequest) => {
+    const res = await api.post<PhoneVerificationConfirmResponse>(
+      '/v1/phone-verifications/phone-change/confirm-code',
+      data
+    )
+    return res.data
+  })
+}
+
+// 내정보 수정 - 일반 프로필정보 (PATCH)
+export const useUpdateProfile = () => {
+  const { setUser } = useUserStore()
+
+  return useSimpleMutation<
+    UpdateProfileResponse['data'],
+    Error,
+    UpdateMeRequest
+  >(
+    async (data: UpdateMeRequest) => {
+      const res = await api.patch<UpdateProfileResponse>(
+        '/v1/users/update-profile',
+        data
+      )
+      return res.data
+    },
+    {
+      // 성공 후에 전역상태 업데이트
+      onSuccess: (responseData: UpdateProfileResponse['data']) => {
+        setUser(responseData as unknown as MeResponse) // MeResponse 타입으로 타입 안전하게
+      },
+
+      invalidateKeys: ['/v1/users/me'], // 캐시무효화
+    }
   )
 }

--- a/src/components/mypage/ProfileContents.tsx
+++ b/src/components/mypage/ProfileContents.tsx
@@ -8,7 +8,6 @@ import UserLeaveModal from './UserLeaveModal'
 import { birthdayFormat } from '../../utils/dateFormat'
 import { phoneFormat } from '../../utils/phoneFormat'
 import { useUserStore, type UserType } from '../../store/useUserStore'
-import { useGetUserMe } from '../../api/services/mypage/profile'
 import { useNavigate } from 'react-router'
 
 function ProfileContents() {
@@ -18,10 +17,6 @@ function ProfileContents() {
 
   // zustand store에서 user 정보 가져오기
   const user = useUserStore((state) => state.user)
-  const setUser = useUserStore((state) => state.setUser)
-
-  // 필요시 refetch할 수 있도록 query 준비 (기본적으로는 실행하지 않음)
-  const { refetch } = useGetUserMe(false)
 
   const navigate = useNavigate()
 
@@ -30,15 +25,6 @@ function ProfileContents() {
       navigate('/login') // user가 없으면 로그인 페이지로 이동
     }
   }, [user, navigate])
-
-  const handleSave = async (_newData: UserType) => {
-    // 저장 성공 후 최신 데이터 refetch
-    const { data } = await refetch()
-
-    if (data) setUser(data)
-
-    setIsModalOpen(false)
-  }
 
   const handleCancel = () => {
     setIsModalOpen(false)
@@ -154,7 +140,6 @@ function ProfileContents() {
         isOpen={isModalOpen}
         profileData={user}
         onClose={handleCancel}
-        onSave={handleSave}
       />
 
       {/* 비밀번호 변경 모달 */}

--- a/src/components/mypage/ProfileEditModal.tsx
+++ b/src/components/mypage/ProfileEditModal.tsx
@@ -1,45 +1,113 @@
-import { useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import Avatar from '../common/Avatar'
 import Button from '../common/Button'
 import InputWithLabel from '../common/InputWithLabel'
 import Modal from '../common/Modal'
-import { phoneFormat } from '../../utils/phoneFormat'
+import {
+  isValidPhoneNumber,
+  phoneFormat,
+  removePhoneFormat,
+} from '../../utils/phoneFormat'
 import { showToast } from '../../utils/showToast'
 import type { UserType } from '../../store/useUserStore'
+import { useNickNameConfirm } from '../../api/services/Auth'
+import type { AxiosError } from 'axios'
+import {
+  useConfirmPhoneVerificationCode,
+  useSendPhoneVerificationCode,
+  useUpdateProfile,
+} from '../../api/services/mypage/profile'
+import type { UpdateMeRequest } from '../../types/apiInterface/mypageInterface'
+import {
+  INIT_NICKNAME_CHECK,
+  INITL_VERIFICATION,
+} from '../../constants/profileEditModal'
 
 interface ProfileEditModalProps {
   isOpen: boolean
   profileData: UserType
   onClose: () => void
-  onSave: (data: UserType) => void
 }
 
 function ProfileEditModal({
   isOpen,
   profileData,
   onClose,
-  onSave,
 }: ProfileEditModalProps) {
   const [tempData, setTempData] = useState<UserType>(profileData) //모달에서 수정 중인 프로필 데이터
-  const [showVerificationInput, setShowVerificationInput] = useState(false) // 휴대폰 인증번호 입력창 표시 여부
-  const [verificationCode, setVerificationCode] = useState('') // 인증번호
-  const [isVerified, setIsVerified] = useState(false) //인증번호 확인 완료 여부
-  const [previewImage, setPreviewImage] = useState<string | null>(null) //선택한 이미지의 미리보기 url (FileReader로 생성한 base64)
-  const [_selectedFile, setSelectedFile] = useState<File | null>(null) // 선택한 이미지 파일 객체
-  const fileInputRef = useRef<HTMLInputElement>(null) // 숨겨진 file input 요소에 접근하기 위한 ref
 
-  const DUMMY_VERIFICATION_CODE = '123456'
+  const [verification, setVerification] = useState(INITL_VERIFICATION)
+  const [nickname, setNickname] = useState(INIT_NICKNAME_CHECK)
+  const [previewImage, setPreviewImage] = useState<string | null>(null)
+  const [_selectedFile, setSelectedFile] = useState<File | null>(null)
 
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  // 휴대폰 인증 api 훅
+  const { mutate: sendVerificationCode, isPending: isSendingCode } =
+    useSendPhoneVerificationCode()
+  const { mutate: confirmVerificationCode, isPending: isConfirmingCode } =
+    useConfirmPhoneVerificationCode()
+  const {
+    isLoading: isNicknameLoading,
+    error: nicknameError,
+    isSuccess: isNicknameSuccess,
+    isError: isNicknameError,
+  } = useNickNameConfirm(tempData.nickname || '', nickname.needsCheck)
+
+  const { mutate: updateProfile, isPending } = useUpdateProfile()
+
+  const resetState = useCallback(() => {
+    setTempData({
+      ...profileData,
+      phone_number: phoneFormat(profileData.phone_number || ''),
+    })
+    setVerification(INITL_VERIFICATION)
+    setNickname(INIT_NICKNAME_CHECK)
+    setPreviewImage(null)
+    setSelectedFile(null)
+  }, [profileData])
+
+  // 모달이 열릴 때마다 상태 초기화
+  useEffect(() => {
+    if (isOpen) resetState()
+  }, [isOpen, resetState])
+
+  // 변경 핸들러 조기 반환 패턴
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target
+    const formattedValue = name === 'phone_number' ? phoneFormat(value) : value
 
-    const formattedValue = name === 'phone' ? phoneFormat(value) : value
+    setTempData((prev) => ({ ...prev, [name]: formattedValue }))
 
-    setTempData((prev) => ({
-      ...prev,
-      [name]: formattedValue,
-    }))
+    // 닉네임 변경시 체크 상태 초기화
+    if (name === 'nickname' && nickname.completed) {
+      setNickname(INIT_NICKNAME_CHECK)
+    }
+
+    // 전화번호 변경시 인증 상태 초기화
+    if (name === 'phone_number' && verification.showInput) {
+      setVerification(INITL_VERIFICATION)
+    }
   }
+
+  // 닉네임 중복확인
+  useEffect(() => {
+    if (!nickname.needsCheck) return
+
+    if (isNicknameSuccess) {
+      setNickname({ needsCheck: false, completed: true, isUse: true })
+      showToast('사용 가능한 닉네임입니다', 'success', '사용 가능')
+    } else if (isNicknameError) {
+      const status = (nicknameError as AxiosError)?.response?.status
+      setNickname({ needsCheck: false, completed: true, isUse: false })
+      const message =
+        status === 409
+          ? '이미 사용 중인 닉네임입니다'
+          : '중복확인에 실패했습니다'
+      showToast(message, 'error', status === 409 ? '사용 불가' : '오류 발생')
+    }
+  }, [isNicknameSuccess, isNicknameError, nickname.needsCheck, nicknameError])
 
   // 파일 선택 핸들러
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -76,61 +144,160 @@ function ProfileEditModal({
     reader.readAsDataURL(file)
   }
 
+  // 휴대폰 인증 처리
+  const handleVerificationSend = () => {
+    const phoneNumber = tempData.phone_number?.trim()
+
+    if (!phoneNumber) {
+      showToast('휴대폰 번호를 입력해주세요', 'error', '입력 오류')
+      return
+    }
+
+    if (!isValidPhoneNumber(phoneNumber)) {
+      showToast(
+        '올바른 휴대폰 번호를 입력해주세요 (010-XXXX-XXXX)',
+        'error',
+        '입력 오류'
+      )
+      return
+    }
+
+    sendVerificationCode(
+      { phone_number: removePhoneFormat(phoneNumber) },
+      {
+        onSuccess: (res) => {
+          setVerification((prev) => ({
+            ...prev,
+            requestId: res.request_id,
+            showInput: true,
+          }))
+          showToast('인증 번호가 전송되었습니다', 'success', '인증번호 전송')
+        },
+        onError: () => {
+          setVerification(INITL_VERIFICATION)
+          showToast('인증 번호 전송에 실패했습니다', 'error', '전송 실패')
+        },
+      }
+    )
+  }
+
+  const handleVerificationConfirm = () => {
+    if (!verification.requestId) {
+      showToast('인증 요청이 유효하지 않습니다', 'error', '오류')
+      return
+    }
+
+    if (!tempData.phone_number) {
+      showToast('휴대폰 번호가 없습니다', 'error', '오류')
+      return
+    }
+
+    confirmVerificationCode(
+      {
+        phone_number: removePhoneFormat(tempData.phone_number),
+        request_id: verification.requestId,
+        code: verification.code,
+      },
+      {
+        onSuccess: (response) => {
+          // verify_token을 응답에서 받아 저장
+          setVerification((prev) => ({
+            ...prev,
+            isVerified: true,
+            verifyToken: response.verify_token || '', // 토큰 저장
+            errorMessage: '',
+          }))
+          showToast('인증이 완료되었습니다', 'success', '인증 완료')
+        },
+        onError: () => {
+          const errorMessage = '인증 번호가 일치하지 않습니다'
+
+          setVerification((prev) => ({
+            ...prev,
+            errorMessage, //에러메시지 저장
+          }))
+          showToast('인증 번호를 확인하세요', 'error', '인증 실패')
+        },
+      }
+    )
+  }
+
   // 프로필 사진 변경 버튼 클릭
   const handleProfileImageClick = () => {
     fileInputRef.current?.click()
   }
 
-  const handleSave = async () => {
-    // 나중에 api 연결할떄 여기서 S3 presigned URL 받아서 업로드
-    // 현재는 미리보기 이미지를 그대로 사용 (로컬 blob URL)
-    if (previewImage) {
-      tempData.profile_img_url = previewImage
+  const handleSave = () => {
+    const isNicknameChanged = tempData.nickname !== profileData.nickname
+    const isPhoneNumberChanged =
+      removePhoneFormat(tempData.phone_number || '') !==
+      removePhoneFormat(profileData.phone_number || '')
+    const isImageChanged = previewImage !== null
+
+    // 변경사항이 없으면 종료
+    if (!isNicknameChanged && !isPhoneNumberChanged && !isImageChanged) {
+      showToast('변경된 내용이 없습니다', 'error', '입력 오류')
+      return
     }
 
-    onSave(tempData)
-    setShowVerificationInput(false)
-    setVerificationCode('')
-    setPreviewImage(null)
-    setSelectedFile(null)
+    // 닉네임 변경했는데 중복확인 안함
+    if (isNicknameChanged && !nickname.completed) {
+      showToast('닉네임 중복확인을 해주세요', 'error', '확인 필요')
+      return
+    }
+
+    // 닉네임이 이미 사용중
+    if (isNicknameChanged && !nickname.isUse) {
+      showToast('사용 불가능한 닉네임입니다', 'error', '재선택 필요')
+      return
+    }
+
+    // 전화번호 변경했는데 인증 안함
+    if (isPhoneNumberChanged && !verification.isVerified) {
+      showToast('휴대폰 인증을 완료해주세요', 'error', '인증 필요')
+      return
+    }
+
+    //  변경된 필드만 요청에 포함 (백엔드에서 포함된 필드만 업데이트)
+    const updateData: UpdateMeRequest = {
+      profile_img_url: previewImage || tempData.profile_img_url,
+    }
+
+    // 닉네임이 변경되었을 때만 포함
+    if (isNicknameChanged) {
+      updateData.nickname = tempData.nickname
+    }
+
+    // 전화번호가 변경되었을때만 포함
+    if (isPhoneNumberChanged) {
+      updateData.phone_number = removePhoneFormat(tempData.phone_number || '')
+      updateData.verify_token = verification.verifyToken
+    }
+
+    // api 호출
+    updateProfile(updateData, {
+      onSuccess: () => {
+        showToast('프로필이 업데이트되었습니다', 'success', '저장 완료')
+        resetState()
+        onClose()
+      },
+      onError: () => {
+        showToast('프로필 업데이트 실패', 'error', '저장 실패')
+      },
+    })
   }
 
   const handleCancel = () => {
-    setTempData(profileData)
-    setShowVerificationInput(false)
-    setVerificationCode('')
-    setIsVerified(false)
-    setPreviewImage(null)
-    setSelectedFile(null)
+    resetState()
     onClose()
   }
-
-  const handleVerificationClick = () => {
-    setShowVerificationInput(true)
-    showToast('인증 번호가 전송되었습니다', 'success', '인증번호 전송')
-  }
-
-  const handleVerificationChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value.replace(/\D/g, '') // 숫자만 허용
-
-    if (value.length <= 6) setVerificationCode(value)
-  }
-
-  const handleVerificationConfirm = () => {
-    if (verificationCode === DUMMY_VERIFICATION_CODE) {
-      setIsVerified(true)
-      showToast('인증이 완료되었습니다', 'success', '인증 완료')
-    } else {
-      showToast('인증 번호를 확인하세요', 'error', '인증 실패')
-    }
-  }
-
-  // 변경하기 버튼 비활성화 (인증 입력창이 보이지만 인증이 완료되지 않은 경우)
-  const isSaveDisabled = showVerificationInput && !isVerified
 
   // 표시할 이미지: 미리보기 > 기존 프로필 이미지
   const displayImage = previewImage || tempData.profile_img_url
 
+  const isPhoneValid = tempData.phone_number
+    ? isValidPhoneNumber(tempData.phone_number)
+    : false
   return (
     <Modal
       title="프로필 수정"
@@ -145,9 +312,9 @@ function ProfileEditModal({
             variant="primary"
             size="md"
             onClick={handleSave}
-            disabled={isSaveDisabled}
+            disabled={isPending}
           >
-            변경하기
+            {isPending ? '저장 중...' : '변경하기'}
           </Button>
         </>
       }
@@ -180,54 +347,86 @@ function ProfileEditModal({
         {/* 입력 필드들 */}
         <div className="w-full space-y-4">
           {/* 닉네임 */}
-          <InputWithLabel
-            label="닉네임"
-            name="nickname"
-            value={tempData.nickname}
-            onChange={handleInputChange}
-            placeholder="닉네임을 입력하세요"
-            required
-            button={{
-              label: '중복확인',
-              variant: 'secondary',
-              onClick: handleVerificationClick,
-            }}
-          />
+          <div>
+            <InputWithLabel
+              label="닉네임"
+              name="nickname"
+              value={tempData.nickname || ''}
+              onChange={handleInputChange}
+              placeholder="닉네임을 입력하세요"
+              required
+              button={{
+                label: isNicknameLoading ? '확인중...' : '중복확인',
+                variant: 'secondary',
+                onClick: () => {
+                  if (!tempData.nickname?.trim()) {
+                    showToast('닉네임을 입력해주세요', 'error', '입력 오류')
+                    return
+                  }
+                  setNickname((prev) => ({ ...prev, needsCheck: true }))
+                },
+                disabled: isNicknameLoading,
+              }}
+            />
+            {/* 닉네임 확인 상태 메시지 */}
+            {nickname.completed && nickname.isUse && (
+              <div className="text-success-500 mt-1 px-4 py-2 text-sm font-semibold">
+                사용 가능한 닉네임입니다
+              </div>
+            )}
+            {nickname.completed && !nickname.isUse && (
+              <div className="text-danger-600 mt-1 px-4 py-2 text-sm font-semibold">
+                이미 사용 중인 닉네임입니다
+              </div>
+            )}
+          </div>
 
           {/* 휴대폰 번호 */}
           <InputWithLabel
             label="휴대폰 번호"
-            name="phone"
+            name="phone_number"
             value={tempData.phone_number}
             onChange={handleInputChange}
             placeholder="휴대폰 번호를 입력하세요"
+            disabled={verification.isVerified} // 인증 완료되면 비활성화
             button={{
-              label: '인증하기',
-              onClick: handleVerificationClick,
+              label: isSendingCode ? '전송중...' : '인증하기',
+              onClick: handleVerificationSend,
               variant: 'secondary',
-              countdown: 180,
+              countdown: verification.showInput ? 180 : undefined,
+              disabled: isSendingCode || !isPhoneValid,
             }}
           />
 
           {/* 인증번호 입력 (조건부렌더) */}
-          {showVerificationInput && (
+          {verification.showInput && (
             <InputWithLabel
               name="verificationCode"
-              value={verificationCode}
-              onChange={handleVerificationChange}
+              value={verification.code}
+              onChange={(e) => {
+                const value = e.target.value.replace(/\D/g, '').slice(0, 6)
+                setVerification((prev) => ({ ...prev, code: value }))
+              }}
               placeholder="인증번호 6자리 입력"
               maxLength={6}
               button={{
-                label: '확인',
+                label: isConfirmingCode ? '확인중...' : '확인',
                 onClick: handleVerificationConfirm,
                 variant: 'primary',
-                disabled: verificationCode.length !== 6,
+                disabled: verification.code.length !== 6 || isConfirmingCode,
               }}
             />
           )}
+          {/* 에러 메시지 표시 */}
+          {verification.errorMessage && (
+            <div className="text-danger-500 mt-1 px-4 py-2 text-sm font-semibold">
+              {verification.errorMessage}
+            </div>
+          )}
+
           {/* 인증 완료 메시지 */}
-          {isVerified && (
-            <div className="text-success-500 rounded-md bg-green-50 px-4 py-2 text-sm">
+          {verification.isVerified && (
+            <div className="text-success-500 mt-1 px-4 py-2 text-sm font-semibold">
               인증이 완료되었습니다
             </div>
           )}

--- a/src/constants/profileEditModal.ts
+++ b/src/constants/profileEditModal.ts
@@ -1,0 +1,16 @@
+// 닉네임 관련 상태 초기화
+export const INIT_NICKNAME_CHECK = {
+  needsCheck: false,
+  completed: false,
+  isUse: false,
+}
+
+// 인증코드 관련 상태 초기화
+export const INITL_VERIFICATION = {
+  showInput: false,
+  code: '',
+  isVerified: false,
+  requestId: '',
+  verifyToken: '',
+  errorMessage: '',
+}

--- a/src/types/apiInterface/mypageInterface.ts
+++ b/src/types/apiInterface/mypageInterface.ts
@@ -13,7 +13,7 @@ export interface MeResponse {
 // 내 정보 수정 - - - - - - - - - - - -
 export interface UpdateMeRequest {
   nickname?: string
-  profile_image_url?: string
+  profile_img_url?: string | null
   phone_number?: string
   verify_token?: string
 }
@@ -328,4 +328,41 @@ export interface PresignedError {
   error: {
     [field: string]: string
   }
+}
+
+// 휴대폰 변경 인증코드 전송 요청
+export interface PhoneVerificationSendRequest {
+  phone_number: string
+}
+
+// 휴대폰 변경 인증코드 전송 응답
+export interface PhoneVerificationSendResponse {
+  detail: string
+  data: {
+    request_id: string
+    expires_in: number
+    cooldown: number
+    max_attempts: number
+  }
+}
+
+// 휴대폰 변경 인증코드 확인 요청
+export interface PhoneVerificationConfirmRequest {
+  phone_number: string
+  request_id: string
+  code: string
+}
+
+// 휴대폰 변경 인증코드 확인 응답
+export interface PhoneVerificationConfirmResponse {
+  detail: string
+  data: {
+    verify_token: string
+  }
+}
+
+// 프로필 업데이트 응답
+export interface UpdateProfileResponse {
+  detail: string
+  data: MeResponse
 }

--- a/src/utils/phoneFormat.ts
+++ b/src/utils/phoneFormat.ts
@@ -15,3 +15,14 @@ export const phoneFormat = (value: string): string => {
 
   return `${limitedNumbers.slice(0, 3)}-${limitedNumbers.slice(3, 7)}-${limitedNumbers.slice(7)}`
 }
+
+// 모든 숫자가 아닌 문자 제거
+export const removePhoneFormat = (value: string): string => {
+  return value.replace(/\D/g, '')
+}
+
+// 010으로 시작하고 11자리 숫자인지 확인
+export const isValidPhoneNumber = (phone: string): boolean => {
+  const cleaned = removePhoneFormat(phone)
+  return /^010\d{8}$/.test(cleaned)
+}


### PR DESCRIPTION
## PR 제목

<!-- 예: [Feat] 로그인 UI 구현 -->
- [Feat] 마이페이지 > 내 정보 수정 API 추가(프로필사진 변경은 s3 api 나오고 추가)
## 관련 이슈

<!-- 예: closes #123 -->
- closes #132 
## 변경 사항 요약

<!-- 변경된 내용을 간단히 작성해주세요 -->
- 마이페이지 > 내 정보 수정하기 API 연동
- 인터페이스 API에 맞춰서 수정
- 닉네임 중복체크 예외처리 완료 (현재는 중복체크해도 상태코드 200 오는데 api가 409로 수정되면 에러메세지 잘 잡음)
- 휴대폰 변경 안하고 닉네임만 변경 가능
- 휴대폰 변경 하면 인증코드 발송 (휴대폰 번호 유효성 검사 유틸함수로 검증함)
- 6자리 입력되면 인증확인 버튼 활성화
- 예외처리 이것저것 많이 추가 하느라 코드가 좀 길어짐.. 추후에 리펙토링도 해볼 예정
- 유틸함수 몇개 추가 (폰 관련)
- 인터셉터에서 에러핸들러는 네트워크오류 발생시에만 잡게 수정

## 체크리스트

- [x] 코드가 빌드되고 실행되는지 확인 (로컬에서)
- [x] 관련 파일 및 문서 수정 여부 확인
- [x] 리뷰 요청 내용 작성
- [x] 코드에 불필요한 console.log & console.error 제거
- [x] PR 제목이 규칙에 맞게 작성됨 (예: [Fix]/[Feat]/[Docs])

## 스크린샷 (선택)

<!-- 스샷 보여주고 싶으면 첨부 -->

## 리뷰어

- @devjaesung
- @chen4023
