### PR TITLE
[Feat] 마이페이지 > 내 정보 비밀번호 변경 API 연동

### DIFF
--- a/src/api/services/mypage/profile.ts
+++ b/src/api/services/mypage/profile.ts
@@ -8,6 +8,8 @@ import type {
   PhoneVerificationConfirmResponse,
   UpdateMeRequest,
   UpdateProfileResponse,
+  UpdatePasswordRequest,
+  UpdatePasswordResponse,
 } from '../../../types/apiInterface/mypageInterface'
 import { useSimpleMutation } from '../../Helper/useSimpleMutation'
 import { useUserStore } from '../../../store/useUserStore'
@@ -76,4 +78,19 @@ export const useUpdateProfile = () => {
       invalidateKeys: ['/v1/users/me'], // 캐시무효화
     }
   )
+}
+
+// 비밀번호 변경 (PATCH)
+export const useChangePassword = () => {
+  return useSimpleMutation<
+    UpdatePasswordResponse,
+    Error,
+    UpdatePasswordRequest
+  >(async (data: UpdatePasswordRequest) => {
+    const res = await api.patch<{ data: UpdatePasswordResponse }>(
+      '/v1/users/change-password',
+      data
+    )
+    return res.data
+  })
 }

--- a/src/api/services/mypage/profile.ts
+++ b/src/api/services/mypage/profile.ts
@@ -87,10 +87,10 @@ export const useChangePassword = () => {
     Error,
     UpdatePasswordRequest
   >(async (data: UpdatePasswordRequest) => {
-    const res = await api.patch<{ data: UpdatePasswordResponse }>(
+    const res = await api.patch<UpdatePasswordResponse>(
       '/v1/users/change-password',
       data
     )
-    return res.data
+    return res
   })
 }

--- a/src/components/mypage/PasswordChangeModal.tsx
+++ b/src/components/mypage/PasswordChangeModal.tsx
@@ -3,30 +3,27 @@ import Modal from '../common/Modal'
 import Button from '../common/Button'
 import InputWithLabel from '../common/InputWithLabel'
 import { showToast } from '../../utils/showToast'
+import { useChangePassword } from '../../api/services/mypage/profile'
+import { validatePasswordChangeField } from '../../utils/passwordValidation'
+import type { AxiosError } from 'axios'
+import type { PasswordChangeErrorResponse } from '../../types/apiInterface/mypageInterface'
+import {
+  INIT_FORM_DATA,
+  INIT_ERRORS,
+} from '../../constants/profilepasswordChange'
 
 interface PasswordChangeModalProps {
   isOpen: boolean
   onClose: () => void
 }
 
-// 폼데이터 초기값
-const INIT_FORM_DATA = {
-  currentPassword: '',
-  newPassword: '',
-  confirmPassword: '',
-}
-
-// 에러 초기값
-const INIT_ERRORS = {
-  currentPassword: '',
-  newPassword: '',
-  confirmPassword: '',
-}
-
 function PasswordChangeModal({ isOpen, onClose }: PasswordChangeModalProps) {
   const [formData, setFormData] = useState(INIT_FORM_DATA)
 
   const [errors, setErrors] = useState(INIT_ERRORS)
+
+  // 비밀번호 변경 api 훅
+  const { mutate: changePassword, isPending } = useChangePassword()
 
   const handleInputChange =
     (field: keyof typeof formData) =>
@@ -37,71 +34,58 @@ function PasswordChangeModal({ isOpen, onClose }: PasswordChangeModalProps) {
       }
     }
 
-  const validateCurrentPassword = () => {
-    if (!formData.currentPassword) {
-      setErrors((prev) => ({
-        ...prev,
-        currentPassword: '현재 비밀번호를 입력하세요',
-      }))
-      return false
-    }
+  // 각 필드 유효성 검사
+  const validateFormField = (field: keyof typeof formData) => {
+    const { isValid, errorMessage } = validatePasswordChangeField(
+      field,
+      formData[field],
+      formData
+    )
 
-    setErrors((prev) => ({ ...prev, currentPassword: '' }))
-    return true
-  }
+    if (!isValid) setErrors((prev) => ({ ...prev, [field]: errorMessage }))
+    else setErrors((prev) => ({ ...prev, [field]: '' }))
 
-  const validateNewPassword = () => {
-    if (!formData.newPassword) {
-      setErrors((prev) => ({
-        ...prev,
-        newPassword: '새 비밀번호를 입력하세요',
-      }))
-      return false
-    }
-    if (formData.newPassword.length < 8) {
-      setErrors((prev) => ({
-        ...prev,
-        newPassword: '비밀번호는 8자 이상이어야 합니다',
-      }))
-      return false
-    }
-    setErrors((prev) => ({ ...prev, newPassword: '' }))
-    return true
-  }
-
-  const validateConfirmPassword = () => {
-    if (!formData.confirmPassword) {
-      setErrors((prev) => ({
-        ...prev,
-        confirmPassword: '비밀번호 확인을 입력하세요',
-      }))
-      return false
-    }
-    if (formData.newPassword !== formData.confirmPassword) {
-      setErrors((prev) => ({
-        ...prev,
-        confirmPassword: '새 비밀번호가 일치하지 않습니다',
-      }))
-      return false
-    }
-    setErrors((prev) => ({ ...prev, confirmPassword: '' }))
-    return true
+    return isValid
   }
 
   const handleSave = () => {
-    const isCurrentValid = validateCurrentPassword()
-    const isNewValid = validateNewPassword()
-    const isConfirmValid = validateConfirmPassword()
+    const isCurrentValid = validateFormField('currentPassword')
+    const isNewValid = validateFormField('newPassword')
+    const isConfirmValid = validateFormField('confirmPassword')
 
     if (!isCurrentValid || !isNewValid || !isConfirmValid) return
 
-    showToast(
-      '비밀번호가 성공적으로 변경되었습니다',
-      'success',
-      '비밀번호 변경 완료'
-    )
+    // api 호출
+    changePassword(
+      {
+        current_password: formData.currentPassword,
+        new_password: formData.newPassword,
+        new_password_confirm: formData.confirmPassword,
+      },
+      {
+        onSuccess: (data) => {
+          showToast(data.detail, 'success', '비밀번호 변경 완료')
+          handleCancel()
+        },
 
-    handleCancel()
+        onError: (error: Error) => {
+          const axiosError = error as AxiosError<PasswordChangeErrorResponse>
+          const errorMessage =
+            axiosError?.response?.data.error ?? '비밀번호 변경에 실패했습니다' // error 필드에서 메시지 추출
+
+          // 현재 비밀번호 오류 감지해서 에러메세지
+          if (errorMessage.includes('현재 비밀번호')) {
+            setErrors((prev) => ({
+              ...prev,
+              currentPassword: errorMessage,
+            }))
+            showToast(errorMessage, 'error', '비밀번호 오류')
+          } else {
+            showToast(errorMessage, 'error', '비밀번호 변경 실패')
+          }
+        },
+      }
+    )
   }
 
   const handleCancel = () => {
@@ -130,9 +114,9 @@ function PasswordChangeModal({ isOpen, onClose }: PasswordChangeModalProps) {
             variant="primary"
             size="md"
             onClick={handleSave}
-            disabled={isCheckField}
+            disabled={isCheckField || isPending}
           >
-            변경하기
+            {isPending ? '변경 중...' : '변경하기'}
           </Button>
         </>
       }
@@ -145,10 +129,11 @@ function PasswordChangeModal({ isOpen, onClose }: PasswordChangeModalProps) {
           type="password"
           value={formData.currentPassword}
           onChange={handleInputChange('currentPassword')}
-          onBlur={validateCurrentPassword}
+          onBlur={() => validateFormField('currentPassword')}
           placeholder="현재 비밀번호를 입력하세요"
           error={errors.currentPassword}
           required
+          disabled={isPending}
         />
 
         {/* 새 비밀번호 */}
@@ -158,10 +143,11 @@ function PasswordChangeModal({ isOpen, onClose }: PasswordChangeModalProps) {
           type="password"
           value={formData.newPassword}
           onChange={handleInputChange('newPassword')}
-          onBlur={validateNewPassword}
+          onBlur={() => validateFormField('newPassword')}
           placeholder="새 비밀번호를 입력하세요 (8자 이상)"
           error={errors.newPassword}
           required
+          disabled={isPending}
         />
 
         {/* 새비밀번호 확인 */}
@@ -171,10 +157,11 @@ function PasswordChangeModal({ isOpen, onClose }: PasswordChangeModalProps) {
           type="password"
           value={formData.confirmPassword}
           onChange={handleInputChange('confirmPassword')}
-          onBlur={validateConfirmPassword}
+          onBlur={() => validateFormField('confirmPassword')}
           placeholder="새 비밀번호를 다시 입력하세요"
           error={errors.confirmPassword}
           required
+          disabled={isPending}
         />
       </div>
     </Modal>

--- a/src/constants/profilepasswordChange.ts
+++ b/src/constants/profilepasswordChange.ts
@@ -1,0 +1,13 @@
+// 폼데이터 초기값
+export const INIT_FORM_DATA = {
+  currentPassword: '',
+  newPassword: '',
+  confirmPassword: '',
+}
+
+// 에러 초기값
+export const INIT_ERRORS = {
+  currentPassword: '',
+  newPassword: '',
+  confirmPassword: '',
+}

--- a/src/types/apiInterface/mypageInterface.ts
+++ b/src/types/apiInterface/mypageInterface.ts
@@ -26,8 +26,14 @@ export interface UpdatePasswordRequest {
   new_password_confirm: string
 }
 
+// 비밀번호 변경 성공
 export interface UpdatePasswordResponse {
   detail: string
+}
+
+// 비밀번호 변경 실패
+export interface PasswordChangeErrorResponse {
+  error: string
 }
 
 // 회원 탈퇴 - - - - - - - - - - - - -

--- a/src/types/apiInterface/mypageInterface.ts
+++ b/src/types/apiInterface/mypageInterface.ts
@@ -25,7 +25,10 @@ export interface UpdatePasswordRequest {
   new_password: string
   new_password_confirm: string
 }
-// 응답 = detail
+
+export interface UpdatePasswordResponse {
+  detail: string
+}
 
 // 회원 탈퇴 - - - - - - - - - - - - -
 export interface MeWithDrawRequest {

--- a/src/utils/passwordValidation.ts
+++ b/src/utils/passwordValidation.ts
@@ -1,0 +1,49 @@
+type ValidationField = 'currentPassword' | 'newPassword' | 'confirmPassword'
+
+// 비밀번호 유효성 검사-  8~15자, 대소문자+숫자+특수문자 포함 필수
+export const isValidPassword = (password: string): boolean => {
+  const passwordRegex =
+    /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*])[a-zA-Z0-9!@#$%^&*]{8,15}$/
+  return passwordRegex.test(password)
+}
+
+export const validatePasswordChangeField = (
+  field: ValidationField,
+  value: string,
+  formData?: { newPassword: string; confirmPassword: string }
+): { isValid: boolean; errorMessage: string } => {
+  switch (field) {
+    case 'currentPassword':
+      if (!value) {
+        return { isValid: false, errorMessage: '현재 비밀번호를 입력하세요' }
+      }
+      return { isValid: true, errorMessage: '' }
+
+    case 'newPassword':
+      if (!value) {
+        return { isValid: false, errorMessage: '새 비밀번호를 입력하세요' }
+      }
+      if (!isValidPassword(value)) {
+        return {
+          isValid: false,
+          errorMessage: '8~15자, 대소문자+숫자+특수문자 포함 해주세요',
+        }
+      }
+      return { isValid: true, errorMessage: '' }
+
+    case 'confirmPassword':
+      if (!value) {
+        return { isValid: false, errorMessage: '비밀번호 확인을 입력하세요' }
+      }
+      if (value !== formData?.newPassword) {
+        return {
+          isValid: false,
+          errorMessage: '새 비밀번호가 일치하지 않습니다',
+        }
+      }
+      return { isValid: true, errorMessage: '' }
+
+    default:
+      return { isValid: true, errorMessage: '' }
+  }
+}


### PR DESCRIPTION
## PR 제목

<!-- 예: [Feat] 로그인 UI 구현 -->
- [Feat] 마이페이지 > 내 정보 비밀번호 변경 API 연동
## 관련 이슈

<!-- 예: closes #123 -->
- closes #137 
## 변경 사항 요약

<!-- 변경된 내용을 간단히 작성해주세요 -->
- useChangePassword 훅 추가
- 비밀번호 변경 response interface 추가
- 비밀번호 유효성 검사 유틸함수 추가  (로그인에 맞게 8~15자리, 대소문자 + 숫자 + 특수문자)
- 폼, 에러 초기상태 상수 contants로 분리
- 비밀번호 변경시 여러 예외처리 추가
## 체크리스트

- [x] 코드가 빌드되고 실행되는지 확인 (로컬에서)
- [x] 관련 파일 및 문서 수정 여부 확인
- [x] 리뷰 요청 내용 작성
- [x] 코드에 불필요한 console.log & console.error 제거
- [x] PR 제목이 규칙에 맞게 작성됨 (예: [Fix]/[Feat]/[Docs])

## 스크린샷 (선택)

<!-- 스샷 보여주고 싶으면 첨부 -->

## 리뷰어

- @devjaesung
- @chen4023
