### PR TITLE
[Refactor] App.tsx 리펙토링 > 인증 초기화 로직, 라우팅설정 분리

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,119 +1,15 @@
 import { useRoutes } from 'react-router'
 import './App.css'
-import LayoutPage from './pages/LayoutPage'
-import MyPage from './pages/MyPage'
-import LoginPage from './pages/LoginPage'
-import SignUpPage from './pages/SignUpPage'
-import MainPage from './pages/MainPage'
-import NotFoundPage from './pages/NotFoundPage'
 import ToastContainer from './components/common/toast/ToastContainer'
-import EmailFindPage from './pages/EmailFindPage'
-import CommonTest from './tests/CommonTest'
-import PasswordFindPage from './pages/PasswordFindPage'
-import { useEffect, useState } from 'react'
-import { useToken } from './store/useTokenStore'
-import { useUserStore } from './store/useUserStore'
-import { api } from './api/client'
-import ApiTestPage from './tests/ApiTestPage'
-import { useGetUserMe } from './api/services/mypage/profile'
-import SocialCallback from './pages/SocialCallback'
+import { useAuthInit } from './hooks/useAuthInit'
+import { routesConfig } from './routes/routes'
 
 function App() {
-  const [isCheck, setIsCheck] = useState(true) //ture는 인증 확인중 / false는 인증 확인 완료
+  const { isAuthCheck, isLoading } = useAuthInit() // 인증 초기화
 
-  const accessToken = useToken((state) => state.accessToken)
-  const setAccessToken = useToken((state) => state.setAccessToken)
+  const routes = useRoutes(routesConfig) //라우트 설정을 기반으로 라우팅 처리
 
-  const user = useUserStore((state) => state.user)
-  const setUser = useUserStore((state) => state.setUser)
-  const clearUser = useUserStore((state) => state.clearUser)
-
-  const {
-    data: meData,
-    isLoading,
-    error,
-  } = useGetUserMe(!!accessToken && !user) // !!accessToken = accessToken이 있으면 true / !user = user가 없으면 true
-
-  useEffect(() => {
-    const initAuth = async () => {
-      //accessToken과 user가 모두 있으면 종료
-      if (accessToken && user) {
-        setIsCheck(false)
-        return
-      }
-
-      try {
-        // refreshToken으로 accessToken 발급
-        const res = await api.post<{
-          detail: string
-          data: {
-            access: string
-          }
-        }>('/v1/auth/refresh', {}, { skipAuth: true })
-
-        const newAccessToken = res.data.access
-        setAccessToken(newAccessToken)
-
-        // user 정보 조회
-        const userRes = await api.get<{
-          id: number
-          email: string
-          nickname: string
-          name: string
-          phone_number: string
-          birthday: string
-          profile_img_url: string | null
-          created_at: string
-        }>('/v1/users/me')
-
-        setUser(userRes)
-      } catch {
-        clearUser() // refreshToken이 없거나 만료 > 로그아웃 상태
-      } finally {
-        setIsCheck(false)
-      }
-    }
-
-    initAuth()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
-  //탠스텍쿼리로 조회한 user 정보 저장
-  useEffect(() => {
-    if (meData) {
-      setUser(meData)
-      setIsCheck(false)
-    }
-  }, [meData, setUser])
-
-  // 에러 발생하면 로그아웃 처리
-  useEffect(() => {
-    if (error) {
-      clearUser()
-      setIsCheck(false)
-    }
-  }, [error, clearUser])
-
-  const routes = useRoutes([
-    {
-      path: '/',
-      element: <LayoutPage />,
-      children: [
-        { index: true, element: <MainPage /> },
-        { path: 'mypage/*', element: <MyPage /> },
-      ],
-    },
-    { path: '/login', element: <LoginPage /> },
-    { path: '/social-callback', element: <SocialCallback /> },
-    { path: '/signup', element: <SignUpPage /> },
-    { path: '/test', element: <CommonTest /> },
-    { path: '/api-test', element: <ApiTestPage /> },
-    { path: '/email-find', element: <EmailFindPage /> },
-    { path: '/password-find', element: <PasswordFindPage /> },
-    { path: '*', element: <NotFoundPage /> },
-  ])
-
-  if (isCheck || isLoading) return
+  if (isAuthCheck || isLoading) return // 인증 확인 중이거나 유저정보를 로딩중일 떄는 아무것도 렌더링x
 
   return (
     <>

--- a/src/hooks/useAuthInit.tsx
+++ b/src/hooks/useAuthInit.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useState } from 'react'
+import { useToken } from '../store/useTokenStore'
+import { useUserStore } from '../store/useUserStore'
+import { useGetUserMe } from '../api/services/mypage/profile'
+import { api } from '../api/client'
+import type { UserLoginResponse } from '../types/apiInterface/authInterface'
+import type { MeResponse } from '../types/apiInterface/mypageInterface'
+
+export const useAuthInit = () => {
+  const [isAuthCheck, setIsAuthCheck] = useState(true) //ture는 인증 확인중 / false는 인증 확인 완료
+
+  const accessToken = useToken((state) => state.accessToken)
+  const setAccessToken = useToken((state) => state.setAccessToken)
+
+  const user = useUserStore((state) => state.user)
+  const setUser = useUserStore((state) => state.setUser)
+  const clearUser = useUserStore((state) => state.clearUser)
+
+  const {
+    data: meData,
+    isLoading,
+    error,
+  } = useGetUserMe(!!accessToken && !user) // !!accessToken = accessToken이 있으면 true / !user = user가 없으면 true
+
+  useEffect(() => {
+    const initAuth = async () => {
+      //accessToken과 user가 모두 있으면 종료
+      if (accessToken && user) {
+        setIsAuthCheck(false)
+        return
+      }
+
+      try {
+        // refreshToken으로 accessToken 발급
+        const res = await api.post<UserLoginResponse>(
+          '/v1/auth/refresh',
+          {},
+          { skipAuth: true }
+        )
+
+        const newAccessToken = res.data.access
+        setAccessToken(newAccessToken)
+
+        // user 정보 조회
+        const userRes = await api.get<MeResponse>('/v1/users/me')
+
+        setUser(userRes)
+      } catch {
+        clearUser() // refreshToken이 없거나 만료 > 로그아웃 상태
+      } finally {
+        setIsAuthCheck(false)
+      }
+    }
+
+    initAuth()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  //탠스텍쿼리로 조회한 user 정보 저장
+  useEffect(() => {
+    if (meData) {
+      setUser(meData)
+      setIsAuthCheck(false)
+    }
+  }, [meData, setUser])
+
+  // 에러 발생하면 로그아웃 처리
+  useEffect(() => {
+    if (error) {
+      clearUser()
+      setIsAuthCheck(false)
+    }
+  }, [error, clearUser])
+
+  return { isAuthCheck, isLoading }
+}

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -1,0 +1,31 @@
+import type { RouteObject } from 'react-router'
+import LayoutPage from '../pages/LayoutPage'
+import MainPage from '../pages/MainPage'
+import MyPage from '../pages/MyPage'
+import LoginPage from '../pages/LoginPage'
+import SignUpPage from '../pages/SignUpPage'
+import EmailFindPage from '../pages/EmailFindPage'
+import PasswordFindPage from '../pages/PasswordFindPage'
+import SocialCallback from '../pages/SocialCallback'
+import NotFoundPage from '../pages/NotFoundPage'
+import CommonTest from '../tests/CommonTest'
+import ApiTestPage from '../tests/ApiTestPage'
+
+export const routesConfig: RouteObject[] = [
+  {
+    path: '/',
+    element: <LayoutPage />,
+    children: [
+      { index: true, element: <MainPage /> },
+      { path: 'mypage/*', element: <MyPage /> },
+    ],
+  },
+  { path: '/login', element: <LoginPage /> },
+  { path: '/social-callback', element: <SocialCallback /> },
+  { path: '/signup', element: <SignUpPage /> },
+  { path: '/test', element: <CommonTest /> },
+  { path: '/api-test', element: <ApiTestPage /> },
+  { path: '/email-find', element: <EmailFindPage /> },
+  { path: '/password-find', element: <PasswordFindPage /> },
+  { path: '*', element: <NotFoundPage /> },
+]


### PR DESCRIPTION
## PR 제목

<!-- 예: [Feat] 로그인 UI 구현 -->
- [Refactor] App.tsx 리펙토링 > 인증 초기화 로직, 라우팅설정 분리
## 관련 이슈

<!-- 예: closes #123 -->
- closes #144 
## 변경 사항 요약

<!-- 변경된 내용을 간단히 작성해주세요 -->
- 기존 App 컴포넌트가 한 번에 인증, 라우팅, UI 렌더링을 담당 했던것을 분리 > 단일 책임 원칙 위반
- 인증 초기화 로직 커스텀 훅으로 분리 > hooks/useAuthInit
- 타입 api interface에 맞춰서 변경
- 라우팅 설정 분리 > routes/routes.tsx
- App컴포넌트 코드 대폭 감소 + 라우트 관리 분리
## 체크리스트

- [x] 코드가 빌드되고 실행되는지 확인 (로컬에서)
- [x] 관련 파일 및 문서 수정 여부 확인
- [x] 리뷰 요청 내용 작성
- [x] 코드에 불필요한 console.log & console.error 제거
- [x] PR 제목이 규칙에 맞게 작성됨 (예: [Fix]/[Feat]/[Docs])

## 스크린샷 (선택)

<!-- 스샷 보여주고 싶으면 첨부 -->

## 리뷰어

- @devjaesung
- @chen4023
