### PR TITLE
[Feat] useDocumentTitle 커스텀 훅 추가

### DIFF
--- a/src/components/mypage/CompletedStudyContents.tsx
+++ b/src/components/mypage/CompletedStudyContents.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import CompletedStudyCard, { type StudyGroup } from './CompletedStudyCard'
+import useDocumentTitle from '../../hooks/useDocumentTitle'
 
 interface completedResponse {
   status: number
@@ -10,6 +11,7 @@ interface completedResponse {
 }
 
 function CompletedStudyContents() {
+  useDocumentTitle('완료된 스터디')
   const [studyGroups, setStudyGroups] = useState<StudyGroup[]>([])
   const [isLoading, setIsLoading] = useState(false)
 

--- a/src/components/mypage/CourseContents.tsx
+++ b/src/components/mypage/CourseContents.tsx
@@ -4,8 +4,10 @@ import useDebounce from '../../hooks/useDebounce'
 import { CourseBookmarkCard } from './BookmarkCard'
 import { showToast } from '../../utils/showToast'
 import type { LectureBookmark } from '../../types/apiInterface/mypageInterface'
+import useDocumentTitle from '../../hooks/useDocumentTitle'
 
 function CourseContents() {
+  useDocumentTitle('북마크한 강의')
   const [courses, setCourses] = useState<LectureBookmark[]>([])
   const [searchQuery, setSearchQuery] = useState('')
   const debouncedSearchQuery = useDebounce(searchQuery)

--- a/src/components/mypage/JobsContents.tsx
+++ b/src/components/mypage/JobsContents.tsx
@@ -5,8 +5,10 @@ import { birthdayFormat } from '../../utils/dateFormat'
 import { JobBookmarkCard } from './BookmarkCard'
 import { showToast } from '../../utils/showToast'
 import type { StudyJobs } from '../../types/apiInterface/mypageInterface'
+import useDocumentTitle from '../../hooks/useDocumentTitle'
 
 function JobsContents() {
+  useDocumentTitle('북마크한 공고')
   const [jobs, setJobs] = useState<StudyJobs[]>([])
   const [searchQuery, setSearchQuery] = useState('')
   const debouncedSearchQuery = useDebounce(searchQuery)

--- a/src/components/mypage/ProfileContents.tsx
+++ b/src/components/mypage/ProfileContents.tsx
@@ -9,8 +9,10 @@ import { birthdayFormat } from '../../utils/dateFormat'
 import { phoneFormat } from '../../utils/phoneFormat'
 import { useUserStore, type UserType } from '../../store/useUserStore'
 import { useNavigate } from 'react-router'
+import useDocumentTitle from '../../hooks/useDocumentTitle'
 
 function ProfileContents() {
+  useDocumentTitle('내 정보')
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [isPasswordModalOpen, setIsPasswordModalOpen] = useState(false)
   const [isWithdrawalModalOpen, setIsWithdrawalModalOpen] = useState(false)

--- a/src/components/mypage/StudysContents.tsx
+++ b/src/components/mypage/StudysContents.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import StudyApplicationCard from './StudyApplicationCard'
 import StudyDetailModal from './StudyDetailModal'
+import useDocumentTitle from '../../hooks/useDocumentTitle'
 
 interface StudyApplication {
   id: number
@@ -23,6 +24,7 @@ interface ApplicationsResponse {
 }
 
 function StudysContents() {
+  useDocumentTitle('지원 내역')
   const [applications, setApplications] = useState<StudyApplication[]>([])
   const [isLoading, setIsLoading] = useState(false)
   const [selectedApplicationId, setSelectedApplicationId] = useState<

--- a/src/hooks/useDocumentTitle.tsx
+++ b/src/hooks/useDocumentTitle.tsx
@@ -1,0 +1,9 @@
+import { useEffect } from 'react'
+
+function useDocumentTitle(title?: string): void {
+  useEffect(() => {
+    document.title = title ? `StudyHub | ${title}` : 'StudyHub'
+  }, [title])
+}
+
+export default useDocumentTitle

--- a/src/pages/EmailFindPage.tsx
+++ b/src/pages/EmailFindPage.tsx
@@ -4,6 +4,7 @@ import PhoneAuthentication from '../components/find/emailFind/PhoneAuthenticatio
 import Stepper from '../components/find/Stepper'
 import EmailFindFinish from '../components/find/emailFind/EmailFindFinish'
 import UserProfileForm from '../components/find/emailFind/UserProfileForm'
+import useDocumentTitle from '../hooks/useDocumentTitle'
 
 export interface FormData {
   name: string
@@ -14,6 +15,7 @@ export interface FormData {
 }
 
 export default function EmailFindPage() {
+  useDocumentTitle('이메일 찾기')
   const [level, setLevel] = useState(1)
   const [formData, setFormData] = useState<FormData>({
     name: '',

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -12,6 +12,7 @@ import { useUserStore } from '../store/useUserStore'
 import { api } from '../api/client'
 import type { MeResponse } from '../types/apiInterface/mypageInterface'
 import Restore from '../components/restore/Restore'
+import useDocumentTitle from '../hooks/useDocumentTitle'
 
 interface Form {
   email: string
@@ -24,6 +25,7 @@ const FORM_STATE: Form = {
 }
 
 function LoginPage() {
+  useDocumentTitle('로그인')
   const navigate = useNavigate()
   const [form, setForm] = useState<Form>(FORM_STATE)
   const [error, setError] = useState<Record<string, string>>({})

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -3,8 +3,10 @@ import Button from '../components/common/Button'
 import ImageCards from '../components/common/ImageCards'
 import { FeaturesData } from '../components/mainpage'
 import { usePopularCourses } from '../hooks/query/usePopularCourses'
+import useDocumentTitle from '../hooks/useDocumentTitle'
 
 function MainPage() {
+  useDocumentTitle()
   const navigate = useNavigate()
   const { data: courses, isLoading, isError } = usePopularCourses()
   const normalizeBreaks = (text: string) => text.replace(/<br\s*\/?>/gi, '\n')

--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -1,30 +1,36 @@
 import { useNavigate } from 'react-router'
 import Button from '../components/common/Button'
+import useDocumentTitle from '../hooks/useDocumentTitle'
+import Header from '../components/layout/Header'
 
 export default function NotFoundPage() {
+  useDocumentTitle('404 Not Found')
   const navigate = useNavigate()
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-gray-50 px-6 text-center">
-      <h1 className="text-primary-500 text-[80px] font-bold">404</h1>
-      <h2 className="mt-4 text-2xl font-semibold text-gray-800">
-        찾으시는 페이지가 없습니다
-      </h2>
+    <>
+      <Header />
+      <div className="mt-20 flex min-h-screen flex-col items-center bg-gray-50 px-6 text-center">
+        <h1 className="text-primary-500 text-[80px] font-bold">404</h1>
+        <h2 className="mt-4 text-2xl font-semibold text-gray-800">
+          찾으시는 페이지가 없습니다
+        </h2>
 
-      <p className="mt-4 leading-relaxed whitespace-pre-line text-gray-600">
-        {`방문하시려는 페이지의 주소가 잘못 입력되었거나, 삭제되어 사용하실 수 없습니다.
+        <p className="mt-4 leading-relaxed whitespace-pre-line text-gray-600">
+          {`방문하시려는 페이지의 주소가 잘못 입력되었거나, 삭제되어 사용하실 수 없습니다.
         입력하신 주소가 정확한지 다시 한 번 확인해 주세요.`}
-      </p>
+        </p>
 
-      <div className="mt-8">
-        <Button
-          variant="primary"
-          size="md"
-          onClick={() => navigate('/', { replace: true })}
-        >
-          홈으로 가기 →
-        </Button>
+        <div className="mt-8">
+          <Button
+            variant="primary"
+            size="md"
+            onClick={() => navigate('/', { replace: true })}
+          >
+            홈으로 가기 →
+          </Button>
+        </div>
       </div>
-    </div>
+    </>
   )
 }

--- a/src/pages/PasswordFindPage.tsx
+++ b/src/pages/PasswordFindPage.tsx
@@ -3,6 +3,7 @@ import Stepper from '../components/find/Stepper'
 import EmailAuthentication from '../components/find/passwordFind/EmailAuthentication'
 import PasswordFindFinish from '../components/find/passwordFind/PasswordFindFinish'
 import PasswordFindEmailForm from '../components/find/passwordFind/PasswordFindEmailForm'
+import useDocumentTitle from '../hooks/useDocumentTitle'
 
 export interface PasswordFormData {
   email: string
@@ -14,6 +15,7 @@ export interface PasswordFormData {
 }
 
 export default function PasswordFindPage() {
+  useDocumentTitle('비밀번호 찾기')
   const [level, setLevel] = useState(1)
   const [formData, setFormData] = useState<PasswordFormData>({
     email: '',

--- a/src/pages/SignUpPage.tsx
+++ b/src/pages/SignUpPage.tsx
@@ -17,6 +17,7 @@ import {
 } from '../api/services/Auth'
 import { birthdayFormat2 } from '../utils/dateFormat'
 import { showToast } from '../utils/showToast'
+import useDocumentTitle from '../hooks/useDocumentTitle'
 
 export interface Form {
   name: string
@@ -89,6 +90,7 @@ const switchInput = (name: string, value: string): string => {
 }
 
 function SignUpPage() {
+  useDocumentTitle('회원가입')
   const navigate = useNavigate()
 
   const [form, setForm] = useState<Form>(FORM_STATE)

--- a/src/tests/ApiTestPage.tsx
+++ b/src/tests/ApiTestPage.tsx
@@ -4,6 +4,7 @@ import { useToken } from '../store/useTokenStore'
 import { useUserStore, type UserType } from '../store/useUserStore'
 import { useSimpleMutation } from '../api/Helper/useSimpleMutation'
 import Button from '../components/common/Button'
+import useDocumentTitle from '../hooks/useDocumentTitle'
 
 interface ApiTest {
   id: string
@@ -88,6 +89,7 @@ const API_TESTS: ApiTest[] = [
 ]
 
 export default function ApiTestPage() {
+  useDocumentTitle('API 테스트')
   const [selectedId, setSelectedId] = useState<string>('')
   const { accessToken, setAccessToken, clearAccessToken } = useToken()
   const { user, setUser, clearUser } = useUserStore()

--- a/src/tests/CommonTest.tsx
+++ b/src/tests/CommonTest.tsx
@@ -16,8 +16,10 @@ import Toast from '../components/common/toast/Toast'
 import { toast } from 'sonner'
 import { DropDown } from '../components/common/dropDown'
 import { showToast } from '../utils/showToast'
+import useDocumentTitle from '../hooks/useDocumentTitle'
 
 function CommonTest() {
+  useDocumentTitle('공통 컴포넌트')
   const [formData, setFormData] = useState({
     fullname: '',
     email: '',


### PR DESCRIPTION
## PR 제목

<!-- 예: [Feat] 로그인 UI 구현 -->
- [Feat] useDocumentTitle 커스텀 훅 추가
## 관련 이슈

<!-- 예: closes #123 -->
- closes #149 
## 변경 사항 요약

<!-- 변경된 내용을 간단히 작성해주세요 -->
- useDocumentTitle 커스텀 훅 추가 (페이지별 동적 title)
- 각 페이지 적용 완료
## 체크리스트

- [x] 코드가 빌드되고 실행되는지 확인 (로컬에서)
- [x] 관련 파일 및 문서 수정 여부 확인
- [x] 리뷰 요청 내용 작성
- [x] 코드에 불필요한 console.log & console.error 제거
- [x] PR 제목이 규칙에 맞게 작성됨 (예: [Fix]/[Feat]/[Docs])

## 스크린샷 (선택)

<!-- 스샷 보여주고 싶으면 첨부 -->
<img width="205" height="38" alt="image" src="https://github.com/user-attachments/assets/6c5538c2-ae96-4093-be34-e721764cb51a" />

## 리뷰어

- @devjaesung
- @chen4023
