### PR TITLE
[Fix] 내 정보 휴대폰 인증코드 키값 바뀐거 수정 및 인증코드 발송 예외처리

### DIFF
--- a/src/components/mypage/ProfileEditModal.tsx
+++ b/src/components/mypage/ProfileEditModal.tsx
@@ -204,7 +204,7 @@ function ProfileEditModal({
           setVerification((prev) => ({
             ...prev,
             isVerified: true,
-            verifyToken: response.verify_token || '', // 토큰 저장
+            verifyToken: response.phone_verify_token || '', // 토큰 저장
             errorMessage: '',
           }))
           showToast('인증이 완료되었습니다', 'success', '인증 완료')
@@ -271,7 +271,7 @@ function ProfileEditModal({
     // 전화번호가 변경되었을때만 포함
     if (isPhoneNumberChanged) {
       updateData.phone_number = removePhoneFormat(tempData.phone_number || '')
-      updateData.verify_token = verification.verifyToken
+      updateData.phone_verify_token = verification.verifyToken
     }
 
     // api 호출
@@ -301,6 +301,11 @@ function ProfileEditModal({
 
   // 닉네임이 현재닉네임이면 false
   const isNicknameUnchanged = tempData.nickname === profileData.nickname
+
+  // 휴대폰 번호가 현재 번호와 같으면 true
+  const isPhoneNumberUnchanged =
+    removePhoneFormat(tempData.phone_number || '') ===
+    removePhoneFormat(profileData.phone_number || '')
 
   return (
     <Modal
@@ -398,7 +403,8 @@ function ProfileEditModal({
               onClick: handleVerificationSend,
               variant: 'secondary',
               countdown: verification.showInput ? 180 : undefined,
-              disabled: isSendingCode || !isPhoneValid,
+              disabled:
+                isSendingCode || !isPhoneValid || isPhoneNumberUnchanged,
             }}
           />
 

--- a/src/types/apiInterface/mypageInterface.ts
+++ b/src/types/apiInterface/mypageInterface.ts
@@ -15,7 +15,7 @@ export interface UpdateMeRequest {
   nickname?: string
   profile_img_url?: string | null
   phone_number?: string
-  verify_token?: string
+  phone_verify_token?: string
 }
 // 응답 = MeResponse
 
@@ -374,7 +374,7 @@ export interface PhoneVerificationConfirmRequest {
 export interface PhoneVerificationConfirmResponse {
   detail: string
   data: {
-    verify_token: string
+    phone_verify_token: string
   }
 }
 


### PR DESCRIPTION
## PR 제목

<!-- 예: [Feat] 로그인 UI 구현 -->
- [Fix] 내 정보 휴대폰 인증코드 키값 바뀐거 수정 및 인증코드 발송 예외처리
## 관련 이슈

<!-- 예: closes #123 -->
- closes #155 
## 변경 사항 요약

<!-- 변경된 내용을 간단히 작성해주세요 -->
- 인증코드 키값 바뀐거 수정 verify_token > phone_verify_token
- 휴대폰 번호 현재랑 동일하면 인증하기 버튼 비활성화 (폰 변경 없을 시 그대로 사용)
## 체크리스트

- [x] 코드가 빌드되고 실행되는지 확인 (로컬에서)
- [x] 관련 파일 및 문서 수정 여부 확인
- [x] 리뷰 요청 내용 작성
- [x] 코드에 불필요한 console.log & console.error 제거
- [x] PR 제목이 규칙에 맞게 작성됨 (예: [Fix]/[Feat]/[Docs])

## 스크린샷 (선택)

<!-- 스샷 보여주고 싶으면 첨부 -->

## 리뷰어

- @devjaesung
- @chen4023
