### PR TITLE
Fix: API에 맞게 수정, 인증코드 발송과정 중에 있을 경우 버튼 비활성화

### DIFF
--- a/src/components/find/emailFind/EmailFindFinish.tsx
+++ b/src/components/find/emailFind/EmailFindFinish.tsx
@@ -8,13 +8,12 @@ import type { FormData } from '../../../pages/EmailFindPage'
 interface EmailFindFinishProps {
   formData: FormData
 }
-
 export default function EmailFindFinish({ formData }: EmailFindFinishProps) {
   const navigate = useNavigate()
   const { mutate, data, isPending, isError } = useRecoveryEmail()
 
   useEffect(() => {
-    mutate(formData.verify_token)
+    mutate(formData.phone_verify_token)
   }, [])
 
   return (
@@ -68,7 +67,7 @@ export default function EmailFindFinish({ formData }: EmailFindFinishProps) {
           <Button
             variant="outline"
             size="freeWidthLg"
-            onClick={() => navigate('/passwordfind')}
+            onClick={() => navigate('/password-find')}
           >
             비밀번호 찾기
           </Button>

--- a/src/components/find/emailFind/PhoneAuthentication.tsx
+++ b/src/components/find/emailFind/PhoneAuthentication.tsx
@@ -23,6 +23,7 @@ export default function PhoneAuthentication({
 }: PhoneAuthProps) {
   const { mutate } = useFindEmailConfirmCode()
   const { mutate: codeResendMutate } = useFindEmailSendCode()
+
   const handleSubmit = () => {
     if (!formData.code) {
       showToast(
@@ -42,7 +43,7 @@ export default function PhoneAuthentication({
         onSuccess: (data) => {
           setFormData((prev) => ({
             ...prev,
-            verify_token: data.data.verify_token,
+            phone_verify_token: data.data.phone_verify_token,
           }))
           onNext()
         },

--- a/src/components/find/emailFind/UserProfileForm.tsx
+++ b/src/components/find/emailFind/UserProfileForm.tsx
@@ -19,8 +19,7 @@ export default function UserProfileForm({
   setFormData,
   onNext,
 }: UserProfileFormProps) {
-  const { mutate } = useFindEmailSendCode()
-  // const { isError } = useFindEmailSendCode()
+  const { mutate, isPending } = useFindEmailSendCode()
   const navigate = useNavigate()
   const handleSubmit = () => {
     if (!formData.name || !formData.phone || !phoneReg) {
@@ -91,8 +90,8 @@ export default function UserProfileForm({
         />
       </div>
       <div className="flex w-full flex-col items-center gap-1">
-        <Button size="freeWidthLg" onClick={handleSubmit}>
-          다음 단계
+        <Button size="freeWidthLg" onClick={handleSubmit} disabled={isPending}>
+          {isPending ? '인증코드 전송 중..' : '다음 단계'}
         </Button>
         <Button size="lg" variant="text" onClick={() => navigate('/login')}>
           로그인으로 돌아가기

--- a/src/components/find/passwordFind/EmailAuthentication.tsx
+++ b/src/components/find/passwordFind/EmailAuthentication.tsx
@@ -7,6 +7,7 @@ import {
   useEmailVerificationConfirmCode,
   useEmailVerificationSendCode,
 } from '../../../api/services/find/passwordFind'
+import { useEffect } from 'react'
 
 interface EmailAuthProps {
   formData: PasswordFormData
@@ -23,6 +24,7 @@ export default function EmailAuthentication({
 }: EmailAuthProps) {
   const { mutate } = useEmailVerificationConfirmCode()
   const { mutate: codeResendMutate } = useEmailVerificationSendCode()
+
   const handleSubmit = () => {
     if (!formData.verificationCode) {
       showToast(
@@ -42,7 +44,7 @@ export default function EmailAuthentication({
         onSuccess: (data) => {
           setFormData((prev) => ({
             ...prev,
-            verify_token: data.data.verify_token,
+            email_verify_token: data.data.email_verify_token,
           }))
           onNext()
         },

--- a/src/components/find/passwordFind/EmailAuthentication.tsx
+++ b/src/components/find/passwordFind/EmailAuthentication.tsx
@@ -7,7 +7,6 @@ import {
   useEmailVerificationConfirmCode,
   useEmailVerificationSendCode,
 } from '../../../api/services/find/passwordFind'
-import { useEffect } from 'react'
 
 interface EmailAuthProps {
   formData: PasswordFormData

--- a/src/components/find/passwordFind/PasswordFindEmailForm.tsx
+++ b/src/components/find/passwordFind/PasswordFindEmailForm.tsx
@@ -18,7 +18,7 @@ export default function PasswordFindEmailForm({
   setFormData,
   onNext,
 }: PasswordFindEmailFormProps) {
-  const { mutate } = useEmailVerificationSendCode()
+  const { mutate, isPending } = useEmailVerificationSendCode()
   const navigate = useNavigate()
   const handleSubmit = () => {
     if (!formData.email || emailError) {
@@ -75,8 +75,8 @@ export default function PasswordFindEmailForm({
         />
       </div>
       <div className="flex w-full flex-col items-center gap-1">
-        <Button size="freeWidthLg" onClick={handleSubmit}>
-          인증코드 전송
+        <Button size="freeWidthLg" onClick={handleSubmit} disabled={isPending}>
+          {isPending ? '인증코드 전송 중..' : '인증코드 전송'}
         </Button>
         <Button size="lg" variant="text" onClick={() => navigate('/login')}>
           로그인으로 돌아가기

--- a/src/components/find/passwordFind/PasswordFindFinish.tsx
+++ b/src/components/find/passwordFind/PasswordFindFinish.tsx
@@ -33,7 +33,7 @@ export default function PasswordFindFinish({
           new_password: formData.password,
           new_password_confirm: formData.passwordConfirm,
         },
-        verifyToken: formData.verify_token,
+        verifyToken: formData.email_verify_token,
       },
       {
         onSuccess: () => navigate('/login'),

--- a/src/pages/EmailFindPage.tsx
+++ b/src/pages/EmailFindPage.tsx
@@ -11,7 +11,7 @@ export interface FormData {
   phone: string
   code: string
   request_id: string
-  verify_token: string
+  phone_verify_token: string
 }
 
 export default function EmailFindPage() {
@@ -22,7 +22,7 @@ export default function EmailFindPage() {
     phone: '',
     code: '',
     request_id: '',
-    verify_token: '',
+    phone_verify_token: '',
   })
 
   const handleNextStep = () => setLevel((prev) => prev + 1)

--- a/src/pages/PasswordFindPage.tsx
+++ b/src/pages/PasswordFindPage.tsx
@@ -9,7 +9,7 @@ export interface PasswordFormData {
   email: string
   verificationCode: string
   requestId: string
-  verify_token: string
+  email_verify_token: string
   password: string
   passwordConfirm: string
 }
@@ -21,7 +21,7 @@ export default function PasswordFindPage() {
     email: '',
     verificationCode: '',
     requestId: '',
-    verify_token: '',
+    email_verify_token: '',
     password: '',
     passwordConfirm: '',
   })

--- a/src/types/apiInterface/findInterface.ts
+++ b/src/types/apiInterface/findInterface.ts
@@ -25,7 +25,7 @@ export interface FindEmailConfirmCodeRequest {
 export interface FindEmailConfirmCodeResponse {
   detail: string
   data: {
-    verify_token: string
+    phone_verify_token: string
     expires_in: number
   }
 }
@@ -68,7 +68,7 @@ export interface EmailVerificationConfirmCodeResponse {
   detail: string
   purpose: string
   data: {
-    verify_token: string
+    email_verify_token: string
     expires_in: number
   }
 }


### PR DESCRIPTION
## PR 제목

Fix: API에 맞게 수정, 인증코드 발송과정 중에 있을 경우 버튼 비활성화

## 관련 이슈

closes #164 

## 변경 사항 요약

- api명세서에 맞게 수정
- 인증코드 발송 후 다음 화면으로 넘어가기 전까지 버튼 비활성화..

## 체크리스트

- [ ] 코드가 빌드되고 실행되는지 확인 (로컬에서)
- [ ] 관련 파일 및 문서 수정 여부 확인
- [ ] 리뷰 요청 내용 작성
- [ ] 코드에 불필요한 console.log & console.error 제거
- [x] PR 제목이 규칙에 맞게 작성됨 (예: [Fix]/[Feat]/[Docs])

## 스크린샷 (선택)

<!-- 스샷 보여주고 싶으면 첨부 -->

## 리뷰어

- @devjaesung
- @chen4023
