### PR TITLE
[Feat] 에러바운더리 (get API 나온 북마크한 강의 적용)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "lucide-react": "^0.515.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-error-boundary": "^6.0.0",
         "react-router": "^7.6.2",
         "react-spinners": "^0.17.0",
         "sonner": "^2.0.7",
@@ -261,6 +262,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -5109,6 +5119,18 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-error-boundary": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-6.0.0.tgz",
+      "integrity": "sha512-gdlJjD7NWr0IfkPlaREN2d9uUZUlksrfOx7SX62VRerwXbMY6ftGCIZua1VG1aXFNOimhISsTq+Owp725b9SiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lucide-react": "^0.515.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-error-boundary": "^6.0.0",
     "react-router": "^7.6.2",
     "react-spinners": "^0.17.0",
     "sonner": "^2.0.7",

--- a/src/api/services/mypage/profile.ts
+++ b/src/api/services/mypage/profile.ts
@@ -104,13 +104,18 @@ export const useGetLectureBookmarks = (
 ) => {
   return useSimpleQuery<LectureBookmarksResponse>(
     ['/v1/lectures/bookmarks', page, page_size], // 캐시 키에 파라미터 포함
-    () =>
-      api.get<LectureBookmarksResponse>('/v1/lectures/bookmarks', {
+    async () => {
+      const isError = false // 테스트 플래그, true일 때만 에러 발생
+
+      if (isError) throw new Error('북마크한 강의를 불러오는데 실패했습니다')
+
+      return api.get<LectureBookmarksResponse>('/v1/lectures/bookmarks', {
         params: {
           ...(page !== null && { page }),
           ...(page_size !== null && { page_size }),
         },
-      }),
+      })
+    },
     { enabled }
   )
 }

--- a/src/components/common/ErrorFallback.tsx
+++ b/src/components/common/ErrorFallback.tsx
@@ -1,0 +1,30 @@
+import { AlertCircle } from 'lucide-react'
+import Button from './Button'
+
+interface ErrorFallbackProps {
+  error: Error
+  resetErrorBoundary: () => void
+}
+
+const ErrorFallback = ({ error, resetErrorBoundary }: ErrorFallbackProps) => {
+  const errorMessage = error?.message || '일시적인 오류가 발생했습니다'
+
+  return (
+    <div className="bg-primary-50 flex w-full flex-col items-center justify-center rounded-lg p-4 sm:p-8">
+      <div className="mb-2 flex h-12 w-12 flex-shrink-0 items-center justify-center">
+        <AlertCircle className="text-danger-600 h-6 w-6" />
+      </div>
+      <div className="mb-1 text-center font-semibold text-gray-700 sm:text-lg">
+        문제가 발생했습니다
+      </div>
+      <p className="mb-5 text-center text-xs text-gray-500 sm:text-sm">
+        {errorMessage}
+      </p>
+      <Button variant="primary" onClick={resetErrorBoundary}>
+        다시 시도
+      </Button>
+    </div>
+  )
+}
+
+export default ErrorFallback

--- a/src/components/mypage/CourseContents.tsx
+++ b/src/components/mypage/CourseContents.tsx
@@ -1,49 +1,16 @@
 import { useState } from 'react'
 import { Search } from 'lucide-react'
 import useDebounce from '../../hooks/useDebounce'
-import { CourseBookmarkCard } from './BookmarkCard'
-import { showToast } from '../../utils/showToast'
 import useDocumentTitle from '../../hooks/useDocumentTitle'
-import {
-  useGetLectureBookmarks,
-  useRemoveLectureBookmark,
-} from '../../api/services/mypage/profile'
+import { QueryErrorResetBoundary } from '@tanstack/react-query'
+import { ErrorBoundary } from 'react-error-boundary'
+import CourseContentsList from './CourseContentsList'
+import ErrorFallback from '../common/ErrorFallback'
 
 function CourseContents() {
   useDocumentTitle('북마크한 강의')
   const [searchQuery, setSearchQuery] = useState('')
   const debouncedSearchQuery = useDebounce(searchQuery)
-
-  // api 호출
-  const { data: response, isLoading } = useGetLectureBookmarks()
-  const courses = response?.data.results || []
-
-  const { mutate: removeBookmark } = useRemoveLectureBookmark()
-
-  const handleBookmarkToggle = (lectureUuid: string) => {
-    removeBookmark(lectureUuid, {
-      onSuccess: () => {
-        showToast('북마크가 삭제되었습니다', 'success', '북마크 삭제')
-      },
-      onError: () => {
-        showToast('북마크 삭제 실패', 'error', '오류 발생')
-      },
-    })
-  }
-
-  const handleViewClick = (courseUrl: string) => {
-    if (courseUrl) window.open(courseUrl, '_blank') // 새탭에서 열기
-  }
-
-  const filterCourses = courses.filter(
-    (course) =>
-      course.lecture_info.title
-        .toLowerCase()
-        .includes(debouncedSearchQuery.toLowerCase()) ||
-      course.lecture_info.instructor
-        .toLowerCase()
-        .includes(debouncedSearchQuery.toLowerCase())
-  )
 
   return (
     <div className="min-h-screen rounded-xl border border-gray-200 bg-white p-8">
@@ -74,30 +41,16 @@ function CourseContents() {
         </div>
 
         {/* 북마크 리스트 */}
-        <div className="space-y-4">
-          {isLoading ? (
-            [...Array(3)].map((_, index) => (
-              <CourseBookmarkCard key={index} isLoading />
-            ))
-          ) : filterCourses.length === 0 ? (
-            <div className="py-12 text-center text-gray-500">
-              {searchQuery
-                ? '검색 결과가 없습니다'
-                : '북마크한 강의가 없습니다'}
-            </div>
-          ) : (
-            filterCourses.map((course) => (
-              <CourseBookmarkCard
-                key={course.id}
-                data={course}
-                onBookmarkToggle={handleBookmarkToggle}
-                onViewClick={() =>
-                  handleViewClick(course.lecture_info.url_link)
-                }
+        <QueryErrorResetBoundary>
+          {({ reset }) => (
+            <ErrorBoundary onReset={reset} FallbackComponent={ErrorFallback}>
+              <CourseContentsList
+                searchQuery={searchQuery}
+                debouncedSearchQuery={debouncedSearchQuery}
               />
-            ))
+            </ErrorBoundary>
           )}
-        </div>
+        </QueryErrorResetBoundary>
       </div>
     </div>
   )

--- a/src/components/mypage/CourseContentsList.tsx
+++ b/src/components/mypage/CourseContentsList.tsx
@@ -1,0 +1,70 @@
+import { CourseBookmarkCard } from './BookmarkCard'
+import {
+  useGetLectureBookmarks,
+  useRemoveLectureBookmark,
+} from '../../api/services/mypage/profile'
+import { showToast } from '../../utils/showToast'
+
+interface CourseBookmarkListProps {
+  searchQuery: string
+  debouncedSearchQuery: string
+}
+
+function CourseContentsList({
+  searchQuery,
+  debouncedSearchQuery,
+}: CourseBookmarkListProps) {
+  const { data: response, isLoading } = useGetLectureBookmarks()
+  const courses = response?.data.results || []
+  const { mutate: removeBookmark } = useRemoveLectureBookmark()
+
+  const handleBookmarkToggle = (lectureUuid: string) => {
+    removeBookmark(lectureUuid, {
+      onSuccess: () => {
+        showToast('북마크가 삭제되었습니다', 'success', '북마크 삭제')
+      },
+      onError: () => {
+        showToast('북마크 삭제 실패', 'error', '오류 발생')
+      },
+    })
+  }
+
+  const handleViewClick = (courseUrl: string) => {
+    if (courseUrl) window.open(courseUrl, '_blank')
+  }
+
+  const filterCourses = courses.filter(
+    (course) =>
+      course.lecture_info.title
+        .toLowerCase()
+        .includes(debouncedSearchQuery.toLowerCase()) ||
+      course.lecture_info.instructor
+        .toLowerCase()
+        .includes(debouncedSearchQuery.toLowerCase())
+  )
+
+  return (
+    <div className="space-y-4">
+      {isLoading ? (
+        [...Array(3)].map((_, index) => (
+          <CourseBookmarkCard key={index} isLoading />
+        ))
+      ) : filterCourses.length === 0 ? (
+        <div className="py-12 text-center text-gray-500">
+          {searchQuery ? '검색 결과가 없습니다' : '북마크한 강의가 없습니다'}
+        </div>
+      ) : (
+        filterCourses.map((course) => (
+          <CourseBookmarkCard
+            key={course.id}
+            data={course}
+            onBookmarkToggle={handleBookmarkToggle}
+            onViewClick={() => handleViewClick(course.lecture_info.url_link)}
+          />
+        ))
+      )}
+    </div>
+  )
+}
+
+export default CourseContentsList

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -22,6 +22,7 @@ const queryClient = new QueryClient({
       gcTime: 1000 * 60 * 10,
       retry: 1, //useQuery만 해당, useMutation은 기본적으로 retry 하지 않아서 mutation 시키려면 따로 옵션을 mutations: { retry: 0 } 이런 식으로 해야되는데 특정 행동 반복하는 건 위험하니까 안 하는 게 나을 수 있음
       refetchOnWindowFocus: false,
+      throwOnError: true, // 에러를 Error Boundary로 던짐
     },
   },
 })


### PR DESCRIPTION
## PR 제목

<!-- 예: [Feat] 로그인 UI 구현 -->
- [Feat] 에러바운더리 (get API 나온 북마크한 강의 적용)
## 관련 이슈

<!-- 예: closes #123 -->
- closes #166 
## 변경 사항 요약

<!-- 변경된 내용을 간단히 작성해주세요 -->
- 에러 처리를 위해 react-error-boundary 라이브러리 설치
- Error Boundary 도입 : react-error-boundary와 TanStack Query의 QueryErrorResetBoundary 통합
- 에러 처리 컴포넌트 : ErrorFallback 컴포넌트 생성 (Lucide 아이콘  + 반응형)
- API 에러 잡음 : throwOnError: true 옵션으로 API 호출 실패 시 자동 에러 처리
- UX 개선 : 에러 발생하면 다시 시도 버튼 제공  > 자동 재호출

## 전역에서 설정 안한 이유
- 문제 : 한 영역의 에러가 전체 페이지를 먹음
- 사용자 경험 : 페이지가 완전히 흰 화면으로 변함
- 레이아웃 손실 : 헤더 등 페이지의 모든 UI가 사라짐

## 동작 로직
1. API 호출 실패 > throwOnError: true로 에러 throw
2. Error Boundary가 에러 캐치 > ErrorFallback 렌더링
3. 다시 시도 클릭 > QueryErrorResetBoundary의 reset() 호출
4. TanStack Query 캐시 초기화 > API 자동 재호출

## 사용 방법
- useSimpleQuery가 있는 곳(GET 요청)에서 에러 발생 > 꼭 그 컴포넌트를 Error Boundary로 감싸야 함
- 그 위의 부모 컴포넌트에서 Error Boundary 선언 > 자식 컴포넌트의 에러를 캐치
- QueryErrorResetBoundary + ErrorBoundary 함께 사용  > Query 캐시 초기화 + UI 초기화

```tsx
import { QueryErrorResetBoundary } from '@tanstack/react-query'
import { ErrorBoundary } from 'react-error-boundary'
import ErrorFallback from '../common/ErrorFallback'

  {/* 리스트 - 에러 바운더리 내부 */}
  <QueryErrorResetBoundary>
    {({ reset }) => (
      <ErrorBoundary onReset={reset} FallbackComponent={ErrorFallback}>
        <ComponentName  /> // 꼭 컴포넌트 레벨에서 사용해야함
      </ErrorBoundary>
    )}
  </QueryErrorResetBoundary>
```
## 체크리스트

- [x] 코드가 빌드되고 실행되는지 확인 (로컬에서)
- [x] 관련 파일 및 문서 수정 여부 확인
- [x] 리뷰 요청 내용 작성
- [x] 코드에 불필요한 console.log & console.error 제거
- [x] PR 제목이 규칙에 맞게 작성됨 (예: [Fix]/[Feat]/[Docs])

## 스크린샷 (선택)

<!-- 스샷 보여주고 싶으면 첨부 -->
<img width="968" height="509" alt="image" src="https://github.com/user-attachments/assets/facd1ba3-3be2-4aae-9641-63f81b00c63b" />

## 리뷰어

- @devjaesung
- @chen4023
