### PR TITLE
[HotFix] 닉네임 중복확인 200 응답외에 흰 화면으로 변하는 버그 수정

### DIFF
--- a/src/api/services/Auth.tsx
+++ b/src/api/services/Auth.tsx
@@ -32,6 +32,7 @@ export const useNickNameConfirm = (nickname: string, enabled = false) => {
     {
       enabled: enabled && nickname.length > 0,
       retry: false,
+      throwOnError: false,
     }
   )
 }


### PR DESCRIPTION
## PR 제목

<!-- 예: [Feat] 로그인 UI 구현 -->
- [HotFix] 닉네임 중복확인 200 성공 응답외에 흰 화면으로 변하는 버그 수정
## 관련 이슈

<!-- 예: closes #123 -->
- closes #172 
## 변경 사항 요약

<!-- 변경된 내용을 간단히 작성해주세요 -->
- 사용가능한 닉네임 (200응답) 외에 전부 white screen 에러 수정
- 리엑트에서 잡히지 않은 에러가 발생해서 전체 컴포넌트 트리가 언마운트되었기 때문인 현상
- 즉 hook에서 에러가 발생했을 떄 적절히 처리되지 않아서 리엑트가 전체 앱을 언마운트 시킨 것 떄문에
-  throwOnError: false,  > 에러를 throw하지 않게 바꿈
## 체크리스트

- [x] 코드가 빌드되고 실행되는지 확인 (로컬에서)
- [x] 관련 파일 및 문서 수정 여부 확인
- [x] 리뷰 요청 내용 작성
- [x] 코드에 불필요한 console.log & console.error 제거
- [x] PR 제목이 규칙에 맞게 작성됨 (예: [Fix]/[Feat]/[Docs])

## 스크린샷 (선택)

<!-- 스샷 보여주고 싶으면 첨부 -->

## 리뷰어

- @devjaesung
- @chen4023
