### PR TITLE
[Fix] 랜딩페이지 / 이미지 카드 UI 및 구조 개선

### DIFF
--- a/src/components/common/ImageCards.tsx
+++ b/src/components/common/ImageCards.tsx
@@ -13,17 +13,19 @@ export default function ImageCards({
   date,
   imageUrl,
   onClick,
-  size = 'w-[24rem] h-[17.375rem]',
+  size = 'w-[389.33px] h-[387.88px]',
 }: ImageCardProps) {
   return (
     <div
-      className={`${size} relative rounded-lg duration-300 select-none hover:-translate-y-[.3rem] hover:shadow-[0_0_.9375rem_#00000020] hover:transition-all`}
+      className={`${size} relative flex flex-col overflow-hidden rounded-xl bg-white shadow-sm transition-transform duration-300 select-none hover:-translate-y-[.3rem] hover:shadow-[0_0_.9375rem_#00000020]`}
     >
-      <img
-        className="h-full w-full rounded-lg object-cover"
-        src={imageUrl}
-        alt={title}
-      />
+      <div className="h-[217.86px] w-full">
+        <img
+          className="h-full w-full object-cover"
+          src={imageUrl}
+          alt={title}
+        />
+      </div>
       <div
         className={`absolute bottom-0 flex w-full flex-col gap-3 rounded-b-lg border-2 border-gray-200 bg-white p-[1.5625rem]`}
       >
@@ -31,12 +33,6 @@ export default function ImageCards({
         <p className="[word-break:keep-all]">{description}</p>
         <div className="flex justify-between">
           <p className="text-[.875rem] font-light text-gray-500">{date}</p>
-          <button
-            onClick={onClick}
-            className="text-primary-600 hover:text-primary-700 active:text-primary-800"
-          >
-            읽어보기
-          </button>
         </div>
       </div>
     </div>

--- a/src/components/common/ImageCards.tsx
+++ b/src/components/common/ImageCards.tsx
@@ -4,7 +4,6 @@ export interface ImageCardProps {
   date: string
   imageUrl: string
   size?: string
-  onClick?: () => void
 }
 
 export default function ImageCards({
@@ -12,20 +11,17 @@ export default function ImageCards({
   description,
   date,
   imageUrl,
-  onClick,
-  size = 'w-[389.33px] h-[387.88px]',
+  size = 'w-[24rem] h-[17.375rem]',
 }: ImageCardProps) {
   return (
     <div
-      className={`${size} relative flex flex-col overflow-hidden rounded-xl bg-white shadow-sm transition-transform duration-300 select-none hover:-translate-y-[.3rem] hover:shadow-[0_0_.9375rem_#00000020]`}
+      className={`${size} relative rounded-lg duration-300 select-none hover:-translate-y-[.3rem] hover:shadow-[0_0_.9375rem_#00000020] hover:transition-all`}
     >
-      <div className="h-[217.86px] w-full">
-        <img
-          className="h-full w-full object-cover"
-          src={imageUrl}
-          alt={title}
-        />
-      </div>
+      <img
+        className="h-full w-full rounded-lg object-cover"
+        src={imageUrl}
+        alt={title}
+      />
       <div
         className={`absolute bottom-0 flex w-full flex-col gap-3 rounded-b-lg border-2 border-gray-200 bg-white p-[1.5625rem]`}
       >
@@ -33,6 +29,9 @@ export default function ImageCards({
         <p className="[word-break:keep-all]">{description}</p>
         <div className="flex justify-between">
           <p className="text-[.875rem] font-light text-gray-500">{date}</p>
+          <button className="text-primary-600 hover:text-primary-700 active:text-primary-800">
+            읽어보기
+          </button>
         </div>
       </div>
     </div>

--- a/src/components/mainpage/PopularCoursesCard.tsx
+++ b/src/components/mainpage/PopularCoursesCard.tsx
@@ -1,0 +1,73 @@
+import StarRating from '../common/StarRating'
+
+export interface PopularCoursesCardrops {
+  title: string
+  description: string
+  date: string
+  imageUrl: string
+  instructor?: string
+  original_price?: number
+  discount_price?: number
+  average_rating?: number
+  size?: string
+  onClick?: () => void
+}
+
+export default function PopularCoursesCard({
+  title,
+  description,
+  date,
+  imageUrl,
+  instructor,
+  original_price,
+  discount_price,
+  average_rating,
+  onClick,
+  size = 'w-[389.33px] h-[387.88px]',
+}: PopularCoursesCardrops) {
+  return (
+    <div
+      className={`${size} relative flex flex-col overflow-hidden rounded-xl bg-white shadow-sm transition-transform duration-300 select-none hover:-translate-y-[.3rem] hover:shadow-[0_0_.9375rem_#00000020]`}
+      onClick={onClick}
+    >
+      <div className="h-[217.86px] w-full">
+        <img
+          className="h-full w-full object-cover"
+          src={imageUrl}
+          alt={title}
+        />
+      </div>
+
+      <div className="absolute bottom-0 flex w-full flex-col gap-2 rounded-b-lg border-t-2 border-gray-200 bg-white p-4">
+        <p className="text-[1.125rem] font-bold">{title}</p>
+        {instructor && <p className="text-sm text-gray-600">{instructor}</p>}
+        <p className="[word-break:keep-all] text-gray-700">{description}</p>
+
+        {average_rating !== undefined && (
+          <div className="mt-1">
+            <StarRating rating={average_rating} size="sm" />
+          </div>
+        )}
+
+        {(original_price !== undefined || discount_price !== undefined) && (
+          <div className="mt-2 flex items-center justify-between">
+            {original_price && original_price > 0 && (
+              <p className="text-sm text-gray-400 line-through">
+                ₩{original_price.toLocaleString()}
+              </p>
+            )}
+            {discount_price && discount_price > 0 ? (
+              <p className="text-primary-500 text-lg font-semibold">
+                ₩{discount_price.toLocaleString()}
+              </p>
+            ) : discount_price === 0 ? (
+              <p className="text-primary-500 text-lg font-semibold">무료</p>
+            ) : null}
+          </div>
+        )}
+
+        <p className="mt-1 text-[0.75rem] font-light text-gray-500">{date}</p>
+      </div>
+    </div>
+  )
+}

--- a/src/components/mainpage/PopularCoursesCard.tsx
+++ b/src/components/mainpage/PopularCoursesCard.tsx
@@ -1,30 +1,26 @@
 import StarRating from '../common/StarRating'
+import type { Lecture } from '../../types/apiInterface/mainpageInterface'
 
-export interface PopularCoursesCardrops {
-  title: string
-  description: string
-  date: string
-  imageUrl: string
-  instructor?: string
-  original_price?: number
-  discount_price?: number
-  average_rating?: number
-  size?: string
+export interface PopularCoursesCardProps {
+  course: Lecture
   onClick?: () => void
+  size?: string
 }
 
 export default function PopularCoursesCard({
-  title,
-  description,
-  date,
-  imageUrl,
-  instructor,
-  original_price,
-  discount_price,
-  average_rating,
+  course,
   onClick,
   size = 'w-[389.33px] h-[387.88px]',
-}: PopularCoursesCardrops) {
+}: PopularCoursesCardProps) {
+  const {
+    title,
+    instructor,
+    original_price,
+    discount_price,
+    average_rating,
+    thumbnail_img_url,
+  } = course
+
   return (
     <div
       className={`${size} relative flex flex-col overflow-hidden rounded-xl bg-white shadow-sm transition-transform duration-300 select-none hover:-translate-y-[.3rem] hover:shadow-[0_0_.9375rem_#00000020]`}
@@ -33,7 +29,7 @@ export default function PopularCoursesCard({
       <div className="h-[217.86px] w-full">
         <img
           className="h-full w-full object-cover"
-          src={imageUrl}
+          src={thumbnail_img_url}
           alt={title}
         />
       </div>
@@ -41,7 +37,6 @@ export default function PopularCoursesCard({
       <div className="absolute bottom-0 flex w-full flex-col gap-2 rounded-b-lg border-t-2 border-gray-200 bg-white p-4">
         <p className="text-[1.125rem] font-bold">{title}</p>
         {instructor && <p className="text-sm text-gray-600">{instructor}</p>}
-        <p className="[word-break:keep-all] text-gray-700">{description}</p>
 
         {average_rating !== undefined && (
           <div className="mt-1">
@@ -65,8 +60,6 @@ export default function PopularCoursesCard({
             ) : null}
           </div>
         )}
-
-        <p className="mt-1 text-[0.75rem] font-light text-gray-500">{date}</p>
       </div>
     </div>
   )

--- a/src/components/mainpage/PopularCoursesCard.tsx
+++ b/src/components/mainpage/PopularCoursesCard.tsx
@@ -23,7 +23,7 @@ export default function PopularCoursesCard({
 
   return (
     <div
-      className={`${size} relative flex flex-col overflow-hidden rounded-xl bg-white shadow-sm transition-transform duration-300 select-none hover:-translate-y-[.3rem] hover:shadow-[0_0_.9375rem_#00000020]`}
+      className={`${size} relative flex flex-col overflow-hidden rounded-2xl bg-white shadow-sm transition-transform duration-300 select-none hover:-translate-y-[.3rem] hover:shadow-[0_0_.9375rem_#00000020]`}
       onClick={onClick}
     >
       <div className="h-[217.86px] w-full">
@@ -34,30 +34,45 @@ export default function PopularCoursesCard({
         />
       </div>
 
-      <div className="absolute bottom-0 flex w-full flex-col gap-2 rounded-b-lg border-t-2 border-gray-200 bg-white p-4">
-        <p className="text-[1.125rem] font-bold">{title}</p>
-        {instructor && <p className="text-sm text-gray-600">{instructor}</p>}
+      <div className="absolute bottom-0 flex w-full flex-col gap-2 rounded-b-2xl border-t border-gray-200 bg-white p-4">
+        <p className="line-clamp-2 text-[18px] leading-snug font-semibold text-[#111827]">
+          {title}
+        </p>
+
+        {instructor && (
+          <p className="text-[14px] font-normal text-[#6B7280]">{instructor}</p>
+        )}
 
         {average_rating !== undefined && (
-          <div className="mt-1">
+          <div className="mt-1 flex items-center gap-1">
             <StarRating rating={average_rating} size="sm" />
+            <span className="text-[14px] font-normal text-[#6B7280]"></span>
           </div>
         )}
 
         {(original_price !== undefined || discount_price !== undefined) && (
-          <div className="mt-2 flex items-center justify-between">
+          <div className="mt-2 flex items-center gap-2">
+            {discount_price &&
+              discount_price > 0 &&
+              discount_price !== original_price && (
+                <p className="text-[18px] font-bold text-[#111827]">
+                  {discount_price.toLocaleString()}원
+                </p>
+              )}
+
             {original_price && original_price > 0 && (
-              <p className="text-sm text-gray-400 line-through">
-                ₩{original_price.toLocaleString()}
+              <p
+                className={`${
+                  discount_price &&
+                  discount_price > 0 &&
+                  discount_price !== original_price
+                    ? 'text-[14px] text-[#6B7280] line-through'
+                    : 'text-[18px] font-bold text-[#111827]'
+                }`}
+              >
+                {original_price.toLocaleString()}원
               </p>
             )}
-            {discount_price && discount_price > 0 ? (
-              <p className="text-primary-500 text-lg font-semibold">
-                ₩{discount_price.toLocaleString()}
-              </p>
-            ) : discount_price === 0 ? (
-              <p className="text-primary-500 text-lg font-semibold">무료</p>
-            ) : null}
           </div>
         )}
       </div>

--- a/src/hooks/query/usePopularCourses.ts
+++ b/src/hooks/query/usePopularCourses.ts
@@ -1,22 +1,6 @@
 import { useSimpleQuery } from '../../api/Helper/useSimpleQuery'
 import { api } from '../../api/client'
-
-export interface Lecture {
-  id: number
-  uuid: string
-  title: string
-  instructor: string
-  thumbnail_img_url: string
-  categories: { id: number; name: string }[]
-  difficulty: string
-  original_price: number
-  discount_price: number
-  platform: string
-  average_rating: number
-  duration: number
-  url_link: string
-  is_bookmarked: boolean
-}
+import type { Lecture } from '../../types/apiInterface/mainpageInterface.ts'
 
 const fetchPopularCourses = async (): Promise<Lecture[]> => {
   const response = await api.get<{

--- a/src/hooks/query/usePopularCourses.ts
+++ b/src/hooks/query/usePopularCourses.ts
@@ -1,6 +1,6 @@
 import { useSimpleQuery } from '../../api/Helper/useSimpleQuery'
 import { api } from '../../api/client'
-import type { Lecture } from '../../types/apiInterface/mainpageInterface.ts'
+import type { Lecture } from '../../types/apiInterface/.ts'
 
 const fetchPopularCourses = async (): Promise<Lecture[]> => {
   const response = await api.get<{

--- a/src/hooks/query/usePopularCourses.ts
+++ b/src/hooks/query/usePopularCourses.ts
@@ -1,6 +1,6 @@
 import { useSimpleQuery } from '../../api/Helper/useSimpleQuery'
 import { api } from '../../api/client'
-import type { Lecture } from '../../types/apiInterface/.ts'
+import type { Lecture } from '../../types/apiInterface/mainpageInterface'
 
 const fetchPopularCourses = async (): Promise<Lecture[]> => {
   const response = await api.get<{

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -144,14 +144,7 @@ function MainPage() {
                     {courses.map((course) => (
                       <PopularCoursesCard
                         key={course.uuid}
-                        title={course.title}
-                        description=""
-                        instructor={course.instructor}
-                        original_price={course.original_price}
-                        discount_price={course.discount_price}
-                        average_rating={course.average_rating}
-                        date=""
-                        imageUrl={course.thumbnail_img_url}
+                        course={course}
                         onClick={() => navigate(course.url_link)}
                       />
                     ))}

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from 'react-router'
 import Button from '../components/common/Button'
-import ImageCards from '../components/common/ImageCards'
+import PopularCoursesCard from '../components/mainpage/PopularCoursesCard'
 import { FeaturesData } from '../components/mainpage'
 import { usePopularCourses } from '../hooks/query/usePopularCourses'
 import useDocumentTitle from '../hooks/useDocumentTitle'
@@ -142,11 +142,15 @@ function MainPage() {
                 {!isLoading && !isError && (
                   <div className="flex flex-wrap justify-center gap-8 sm:gap-10">
                     {courses.map((course) => (
-                      <ImageCards
+                      <PopularCoursesCard
                         key={course.uuid}
                         title={course.title}
-                        description={course.instructor}
-                        date={`${course.discount_price.toLocaleString()}원`}
+                        description=""
+                        instructor={course.instructor}
+                        original_price={course.original_price}
+                        discount_price={course.discount_price}
+                        average_rating={course.average_rating}
+                        date=""
                         imageUrl={course.thumbnail_img_url}
                         onClick={() => navigate(course.url_link)}
                       />

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -148,7 +148,6 @@ function MainPage() {
                         description={course.instructor}
                         date={`${course.discount_price.toLocaleString()}원`}
                         imageUrl={course.thumbnail_img_url}
-                        size={`w-full sm:w-[384px] h-[17.375rem]`}
                         onClick={() => navigate(course.url_link)}
                       />
                     ))}

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -149,7 +149,7 @@ function MainPage() {
                         date={`${course.discount_price.toLocaleString()}원`}
                         imageUrl={course.thumbnail_img_url}
                         size={`w-full sm:w-[384px] h-[17.375rem]`}
-                        onClick={() => navigate(`/courses/${course.uuid}`)}
+                        onClick={() => navigate(course.url_link)}
                       />
                     ))}
                   </div>

--- a/src/types/apiInterface/mainpageInterface.ts
+++ b/src/types/apiInterface/mainpageInterface.ts
@@ -1,0 +1,16 @@
+export interface Lecture {
+  id: number
+  uuid: string
+  title: string
+  instructor: string
+  thumbnail_img_url: string
+  categories: { id: number; name: string }[]
+  difficulty: string
+  original_price: number
+  discount_price: number
+  platform: string
+  average_rating: number
+  duration: number
+  url_link: string
+  is_bookmarked: boolean
+}


### PR DESCRIPTION
## PR 제목

[Fix] 랜딩페이지 / 이미지 카드 UI 및 구조 개선

## 관련 이슈

#180 

## 변경 사항 요약

- 이미지 카드에 할인가와 별점(StarRating) 표시 추가
- navigate 경로를 course.url_link로 변경
- course` 전체를 props로 내려 구조 단순화
- 이미지 크기를 Figma 시안과 동일하게 수정
- 타입 관련 로직을 `mainpageInterface.ts`로 분리하여 관리
## 추가 변경 사항
- 기존 `ImageCard` 컴포넌트 대신 `PopularCoursesCard` 컴포넌트 생성 하여 적용

- [ ] 코드가 빌드되고 실행되는지 확인 (로컬에서)
- [ ] 관련 파일 및 문서 수정 여부 확인
- [ ] 리뷰 요청 내용 작성
- [ ] 코드에 불필요한 console.log & console.error 제거
- [ ] PR 제목이 규칙에 맞게 작성됨 (예: [Fix]/[Feat]/[Docs])

## 스크린샷 (선택)

<img width="944" height="484" alt="스크린샷 2025-11-12 오전 10 36 14" src="https://github.com/user-attachments/assets/629eb04a-adc3-44e3-b03c-2cb0b4206313" />


## 리뷰어

- @devjaesung
- @chen4023
