### PR TITLE
[Feat] 마이페이지 > 회원탈퇴 후 유저정보 초기화, 버튼 타이머 오류 수정

### DIFF
--- a/src/components/common/InputWithLabel.tsx
+++ b/src/components/common/InputWithLabel.tsx
@@ -72,7 +72,8 @@ function InputWithLabel({
     if (button?.start && button?.countdown && button.countdown > 0) {
       start(button.countdown)
     }
-  }, [button?.start, button?.countdown, start])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [button?.start, button?.countdown])
 
   const handleButtonClick = () => {
     button?.onClick()

--- a/src/components/mypage/ProfileEditModal.tsx
+++ b/src/components/mypage/ProfileEditModal.tsx
@@ -418,6 +418,7 @@ function ProfileEditModal({
               label: isSendingCode ? '전송중...' : '인증하기',
               onClick: handleVerificationSend,
               variant: 'secondary',
+              start: verification.showInput,
               countdown: verification.showInput ? 180 : undefined,
               disabled:
                 isSendingCode || !isPhoneValid || isPhoneNumberUnchanged,

--- a/src/components/mypage/UserLeaveModal.tsx
+++ b/src/components/mypage/UserLeaveModal.tsx
@@ -8,6 +8,7 @@ import { showToast } from '../../utils/showToast'
 import { useUserLeave } from '../../api/services/mypage/profile'
 import { useToken } from '../../store/useTokenStore'
 import type { MeWithDrawRequest } from '../../types/apiInterface/mypageInterface'
+import { useUserStore } from '../../store/useUserStore'
 
 interface UserLeaveModalProps {
   isOpen: boolean
@@ -31,6 +32,7 @@ function UserLeaveModal({ isOpen, onClose }: UserLeaveModalProps) {
     useState('서비스 이용할 시간이 없음')
   const [detailReason, setDetailReason] = useState('')
   const [isChecked, setIsChecked] = useState(false)
+  const { clearUser } = useUserStore()
 
   const navigate = useNavigate()
 
@@ -53,6 +55,7 @@ function UserLeaveModal({ isOpen, onClose }: UserLeaveModalProps) {
     userLeave(userLeaveData, {
       onSuccess: () => {
         clearAccessToken()
+        clearUser()
         showToast('이용해주셔서 감사합니다', 'success', '회원탈퇴 성공')
         navigate('/')
         onClose()


### PR DESCRIPTION
## PR 제목

<!-- 예: [Feat] 로그인 UI 구현 -->
- [Feat] 마이페이지 > 회원탈퇴 후 유저정보 초기화, 버튼 타이머 오류 수정
## 관련 이슈

<!-- 예: closes #123 -->
- closes #229 
## 변경 사항 요약

<!-- 변경된 내용을 간단히 작성해주세요 -->
- 회원 탈퇴 후 유저 정보 초기화 추가
- 인증코드 재전송 카운트다운 시간 안가는 오류 수정
## 체크리스트

- [x] 코드가 빌드되고 실행되는지 확인 (로컬에서)
- [x] 관련 파일 및 문서 수정 여부 확인
- [x] 리뷰 요청 내용 작성
- [x] 코드에 불필요한 console.log & console.error 제거
- [x] PR 제목이 규칙에 맞게 작성됨 (예: [Fix]/[Feat]/[Docs])

## 스크린샷 (선택)

<!-- 스샷 보여주고 싶으면 첨부 -->

## 리뷰어

- @devjaesung
- @chen4023
