### PR TITLE
[Fix] 카운트다운, 쿨다운 의도에 맞게 수정

### DIFF
--- a/src/components/common/InputWithLabel.tsx
+++ b/src/components/common/InputWithLabel.tsx
@@ -30,7 +30,7 @@ type InputButtonProps = {
   disabled?: boolean
   countdown?: number
   cooldown?: number
-  start?: boolean
+  start?: number
 }
 
 type InputWithLabelProps = {

--- a/src/components/find/emailFind/PhoneAuthentication.tsx
+++ b/src/components/find/emailFind/PhoneAuthentication.tsx
@@ -7,6 +7,7 @@ import {
   useFindEmailSendCode,
 } from '../../../api/services/find/emailFind'
 import { showToast } from '../../../utils/showToast'
+import { useEffect, useState } from 'react'
 
 interface PhoneAuthProps {
   formData: FormData
@@ -21,8 +22,16 @@ export default function PhoneAuthentication({
   onNext,
   onPrev,
 }: PhoneAuthProps) {
+  const [timerKey, setTimerKey] = useState(0)
+
   const { mutate } = useFindEmailConfirmCode()
   const { mutate: codeResendMutate } = useFindEmailSendCode()
+
+  useEffect(() => {
+    if (formData.expires_in && formData.expires_in > 0) {
+      setTimerKey((prev) => prev + 1)
+    }
+  }, [formData.expires_in])
 
   const handleSubmit = () => {
     if (!formData.code) {
@@ -64,6 +73,8 @@ export default function PhoneAuthentication({
             cooldown: data.data.cooldown,
             //성공헀을 떄만 쿨타임 초기화 되고 실패헀을 떄는 초기화 안 되게..
           }))
+
+          setTimerKey((prev) => prev + 1) // 키값 1 증가 > 이걸로 InputWithLabel의 useEffect 다시 실행 유도
         },
         onError: (data) => {
           showToast(data.error, 'error')
@@ -102,7 +113,7 @@ export default function PhoneAuthentication({
           variant: 'primary',
           countdown: formData.expires_in,
           cooldown: formData.cooldown,
-          start: true,
+          start: timerKey,
         }}
       />
 

--- a/src/components/find/passwordFind/EmailAuthentication.tsx
+++ b/src/components/find/passwordFind/EmailAuthentication.tsx
@@ -7,6 +7,7 @@ import {
   useEmailVerificationConfirmCode,
   useEmailVerificationSendCode,
 } from '../../../api/services/find/passwordFind'
+import { useEffect, useState } from 'react'
 
 interface EmailAuthProps {
   formData: PasswordFormData
@@ -23,6 +24,13 @@ export default function EmailAuthentication({
 }: EmailAuthProps) {
   const { mutate } = useEmailVerificationConfirmCode()
   const { mutate: codeResendMutate } = useEmailVerificationSendCode()
+  const [timerKey, setTimerKey] = useState(0)
+
+  useEffect(() => {
+    if (formData.expires_in && formData.expires_in > 0) {
+      setTimerKey((prev) => prev + 1)
+    }
+  }, [formData.expires_in])
 
   const handleSubmit = () => {
     if (!formData.verificationCode) {
@@ -66,6 +74,7 @@ export default function EmailAuthentication({
             cooldown: data.data.cooldown,
             //성공헀을 떄만 쿨타임 초기화 되고 실패헀을 떄는 초기화 안 되게..
           }))
+          setTimerKey((prev) => prev + 1)
         },
         onError: () => {
           showToast('오류가 발생했습니다. 잠시 후에 시도해주세요.', 'error')
@@ -106,7 +115,7 @@ export default function EmailAuthentication({
           variant: 'primary',
           countdown: formData.expires_in,
           cooldown: formData.cooldown,
-          start: true,
+          start: timerKey,
         }}
       />
       <Button

--- a/src/components/mypage/ProfileEditModal.tsx
+++ b/src/components/mypage/ProfileEditModal.tsx
@@ -34,12 +34,15 @@ function ProfileEditModal({
   onClose,
 }: ProfileEditModalProps) {
   const [tempData, setTempData] = useState<UserType>(profileData) //모달에서 수정 중인 프로필 데이터
-
   const [verification, setVerification] = useState(INITL_VERIFICATION)
   const [nickname, setNickname] = useState(INIT_NICKNAME_CHECK)
   const [previewImage, setPreviewImage] = useState<string | null>(null)
   const [selectedFile, setSelectedFile] = useState<File | null>(null)
-
+  const [timerKey, setTimerKey] = useState(0) // 타이머 키 역할하는 상태
+  const [timer, setTimer] = useState({
+    countdown: 0,
+    cooldown: 0,
+  })
   const fileInputRef = useRef<HTMLInputElement>(null)
 
   // 휴대폰 인증 api 훅
@@ -65,6 +68,8 @@ function ProfileEditModal({
     setNickname(INIT_NICKNAME_CHECK)
     setPreviewImage(null)
     setSelectedFile(null)
+    setTimerKey(0)
+    setTimer({ countdown: 0, cooldown: 0 })
   }, [profileData])
 
   // 모달이 열릴 때마다 상태 초기화
@@ -184,6 +189,14 @@ function ProfileEditModal({
             requestId: res.request_id,
             showInput: true,
           }))
+
+          setTimer({
+            countdown: res.expires_in,
+            cooldown: res.cooldown,
+          })
+
+          setTimerKey((prev) => prev + 1)
+
           showToast('인증 번호가 전송되었습니다', 'success', '인증번호 전송')
         },
         onError: () => {
@@ -418,8 +431,9 @@ function ProfileEditModal({
               label: isSendingCode ? '전송중...' : '인증하기',
               onClick: handleVerificationSend,
               variant: 'secondary',
-              start: verification.showInput,
-              countdown: verification.showInput ? 180 : undefined,
+              start: timerKey,
+              countdown: timer.countdown,
+              cooldown: timer.cooldown,
               disabled:
                 isSendingCode || !isPhoneValid || isPhoneNumberUnchanged,
             }}

--- a/src/pages/SignUpPage.tsx
+++ b/src/pages/SignUpPage.tsx
@@ -108,6 +108,9 @@ function SignUpPage() {
   const [checkNickname, setCheckNickname] = useState(false)
   const [verifyToken, setVerifyToken] = useState(VERIFYTOKEN_STATE)
 
+  const [emailTimerKey, setEmailTimerKey] = useState(0)
+  const [phoneTimerKey, setPhoneTimerKey] = useState(0)
+
   const {
     data: nickNameData,
     error: nicknameError,
@@ -232,6 +235,7 @@ function SignUpPage() {
             emailExpiresIn: data.data.expires_in,
             emailCooldown: data.data.cooldown,
           }))
+          setEmailTimerKey((prev) => prev + 1)
           showToast(`${data.detail}`, 'success', '이메일 코드 전송')
         },
         onError: (error) => {
@@ -290,6 +294,7 @@ function SignUpPage() {
             phoneExpiresIn: data.data.expires_in,
             phoneCooldown: data.data.cooldown,
           }))
+          setPhoneTimerKey((prev) => prev + 1)
           showToast(`${data.detail}`, 'success', '핸드폰 코드 전송')
         },
         onError: (error) => {
@@ -437,7 +442,7 @@ function SignUpPage() {
                   disabled: !(form.email && !error['email'] && !isEmail),
                   countdown: requestId.emailExpiresIn,
                   cooldown: requestId.emailCooldown,
-                  start: true,
+                  start: emailTimerKey,
                 }}
               />
             </div>
@@ -487,7 +492,7 @@ function SignUpPage() {
                   ),
                   countdown: requestId.phoneExpiresIn,
                   cooldown: requestId.phoneCooldown,
-                  start: true,
+                  start: phoneTimerKey,
                 }}
               />
             </div>


### PR DESCRIPTION
## PR 제목

<!-- 예: [Feat] 로그인 UI 구현 -->
- [Fix] 카운트다운, 쿨다운 의도에 맞게 수정
## 관련 이슈

<!-- 예: closes #123 -->
- closes #232 
## 변경 사항 요약

<!-- 변경된 내용을 간단히 작성해주세요 -->
- 인증코드 전송 후 카운트다운 시간에 맞춰서 타이머 시작
- 쿨다운 (재요청못하는시간)에는 비활성 후 쿨다운 시간 지나면 활성화
- 활성화 후 다시 버튼 누르면 타이머 초기화되면서 인증코드 재전송
## 체크리스트

- [x] 코드가 빌드되고 실행되는지 확인 (로컬에서)
- [x] 관련 파일 및 문서 수정 여부 확인
- [x] 리뷰 요청 내용 작성
- [x] 코드에 불필요한 console.log & console.error 제거
- [x] PR 제목이 규칙에 맞게 작성됨 (예: [Fix]/[Feat]/[Docs])

## 스크린샷 (선택)

<!-- 스샷 보여주고 싶으면 첨부 -->

## 리뷰어

- @devjaesung
- @chen4023
