### PR TITLE
[Hotfix] 랜딩페이지 메인배너 이미지 반응형 가운데로 조정

### DIFF
--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -51,7 +51,7 @@ function MainPage() {
         </div>
 
         {/* 오른쪽 이미지 */}
-        <div className="flex h-56 w-full max-w-[340px] items-center justify-center overflow-hidden rounded-2xl shadow-md sm:h-96 sm:max-w-xl">
+        <div className="mx-auto flex h-56 w-full max-w-[340px] items-center justify-center overflow-hidden rounded-2xl shadow-md sm:h-96 sm:max-w-xl">
           <img
             src="/images/mainBannerImg.png"
             alt="스터디룸"


### PR DESCRIPTION
## PR 제목

<!-- 예: [Feat] 로그인 UI 구현 -->
- [Hotfix] 랜딩페이지 메인배너 이미지 반응형 가운데로 조정
## 관련 이슈

<!-- 예: closes #123 -->

## 변경 사항 요약

<!-- 변경된 내용을 간단히 작성해주세요 -->
- 랜딩페이지 메인배너 이미지 반응형 가운데로 조정
## 체크리스트

- [ ] 코드가 빌드되고 실행되는지 확인 (로컬에서)
- [ ] 관련 파일 및 문서 수정 여부 확인
- [ ] 리뷰 요청 내용 작성
- [ ] 코드에 불필요한 console.log & console.error 제거
- [ ] PR 제목이 규칙에 맞게 작성됨 (예: [Fix]/[Feat]/[Docs])

## 스크린샷 (선택)

<!-- 스샷 보여주고 싶으면 첨부 -->

## 리뷰어

- @devjaesung
- @chen4023
